### PR TITLE
feat!: Add bootstrapping

### DIFF
--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/Plugin.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/Plugin.java
@@ -45,7 +45,6 @@ public @interface Plugin {
 	@NotNull String[] authors() default {};
 	@NotNull PlatformDependency[] dependencies() default {};
 
-	@NotNull String logPrefix() default "[%s]";
 	@NotNull Platform[] platforms() default {};
 
 

--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/Generator.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/Generator.java
@@ -23,7 +23,12 @@
 package dev.hypera.chameleon.annotations.processing.generation;
 
 import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
 import dev.hypera.chameleon.annotations.Plugin;
+import dev.hypera.chameleon.annotations.Plugin.Platform;
+import dev.hypera.chameleon.core.data.PluginData;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
 import org.jetbrains.annotations.NotNull;
@@ -34,6 +39,14 @@ public abstract class Generator {
 
     public abstract void generate(@NotNull Plugin data, @NotNull TypeElement plugin, @NotNull ProcessingEnvironment env) throws Exception;
 
+    protected @NotNull CodeBlock createPluginData(@NotNull Plugin data) {
+        return CodeBlock.builder().add(
+            "$T pluginData = new $T($S, $S, $S, $S, $T.asList($L), $T.asList($L))",
+            PluginData.class, PluginData.class, data.name().isEmpty() ? (data.id().isEmpty() ? "Unknown" : data.id()) : data.name(), data.version(), data.description(), data.url(),
+            Arrays.class, data.authors().length > 0 ? '"' + String.join("\",\"", data.authors()) + '"' : "",
+            Arrays.class, CodeBlock.builder().add(Arrays.stream(data.platforms().length > 0 ? data.platforms() : Platform.values()).map(p -> "$1T." + p.name()).collect(Collectors.joining(", ")), PluginData.Platform.class).build()
+        ).build();
+    }
     protected @NotNull ClassName clazz(@NotNull String p, @NotNull String n) {
         return ClassName.get(p, n);
     }

--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/impl/bungeecord/BungeeCordGenerator.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/impl/bungeecord/BungeeCordGenerator.java
@@ -22,7 +22,6 @@
  */
 package dev.hypera.chameleon.annotations.processing.generation.impl.bungeecord;
 
-import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
@@ -32,7 +31,6 @@ import dev.hypera.chameleon.annotations.Plugin;
 import dev.hypera.chameleon.annotations.Plugin.Platform;
 import dev.hypera.chameleon.annotations.processing.generation.Generator;
 import dev.hypera.chameleon.annotations.utils.MapBuilder;
-import dev.hypera.chameleon.core.data.PluginData;
 import dev.hypera.chameleon.core.exceptions.instantiation.ChameleonInstantiationException;
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -54,23 +52,21 @@ public class BungeeCordGenerator extends Generator {
 
     @Override
     public void generate(@NotNull Plugin data, @NotNull TypeElement plugin, @NotNull ProcessingEnvironment env) throws Exception {
-        Platform[] platforms = data.platforms().length > 0 ? data.platforms() : Platform.values();
+        MethodSpec loadSpec = MethodSpec.methodBuilder("onLoad")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .beginControlFlow("try")
+            .addStatement(createPluginData(data))
+            .addStatement("this.$N = $T.create($T.class, this, $N).load()", "chameleon", clazz("dev.hypera.chameleon.platforms.bungeecord", "BungeeCordChameleon"), plugin, "pluginData")
+            .nextControlFlow("catch ($T ex)", ChameleonInstantiationException.class)
+            .addStatement("$N.printStackTrace()", "ex")
+            .endControlFlow()
+            .build();
 
         MethodSpec enableSpec = MethodSpec.methodBuilder("onEnable")
                 .addAnnotation(Override.class)
                 .addModifiers(Modifier.PUBLIC)
-                .beginControlFlow("try")
-                .addStatement(CodeBlock.builder().add(
-                        "$T pluginData = new $T($S, $S, $S, $S, $T.asList($L), $S, $T.asList($L))",
-                        PluginData.class, PluginData.class, data.name(), data.version(), data.description(), data.url(),
-                        Arrays.class, data.authors().length > 0 ? '"' + String.join("\",\"", data.authors()) + '"' : "", data.logPrefix(),
-                        Arrays.class, CodeBlock.builder().add(Arrays.stream(platforms).map(p -> "$1T." + p.name()).collect(Collectors.joining(", ")), PluginData.Platform.class).build()
-                ).build())
-                .addStatement("this.$N = new $T($T.class, this, pluginData)", "chameleon", clazz("dev.hypera.chameleon.platforms.bungeecord", "BungeeCordChameleon"), plugin)
                 .addStatement("this.$N.onEnable()", "chameleon")
-                .nextControlFlow("catch ($T ex)", ChameleonInstantiationException.class)
-                .addStatement("$N.printStackTrace()", "ex")
-                .endControlFlow()
                 .build();
 
         MethodSpec disableSpec = MethodSpec.methodBuilder("onDisable")
@@ -87,6 +83,7 @@ public class BungeeCordGenerator extends Generator {
                         "chameleon",
                         Modifier.PRIVATE
                 ).build())
+                .addMethod(loadSpec)
                 .addMethod(enableSpec)
                 .addMethod(disableSpec)
                 .build();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ plugins {
 }
 
 group = "dev.hypera.chameleon"
-version = "0.6.1-SNAPSHOT"
+version = "0.7.0-SNAPSHOT"
 description = "Cross-platform Minecraft plugin framework"
 
 subprojects {

--- a/core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
+++ b/core/src/main/java/dev/hypera/chameleon/core/Chameleon.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public abstract class Chameleon {
 
-	private static final @NotNull String VERSION = "0.6.1-SNAPSHOT";
+	private static final @NotNull String VERSION = "@version@";
 
 	private final @NotNull ChameleonLogger logger;
 	private final @NotNull ChameleonLogger internalLogger;
@@ -78,6 +78,9 @@ public abstract class Chameleon {
 	}
 
 
+	public final void onLoad() {
+		plugin.onLoad();
+	}
 
 	public final void onEnable() {
 		plugin.onEnable();

--- a/core/src/main/java/dev/hypera/chameleon/core/ChameleonPlugin.java
+++ b/core/src/main/java/dev/hypera/chameleon/core/ChameleonPlugin.java
@@ -36,8 +36,23 @@ public abstract class ChameleonPlugin {
 		this.chameleon = chameleon;
 	}
 
+	/**
+	 * Chameleon load
+	 */
+	public void onLoad() {
+
+	}
+
+	/**
+	 * Platform plugin enable
+	 */
 	public abstract void onEnable();
+
+	/**
+	 * Platform plugin disable
+	 */
 	public abstract void onDisable();
+
 
 	public final @NotNull PluginData getData() {
 		return chameleon.getData();

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platforms/bungeecord/BungeeCordChameleon.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platforms/bungeecord/BungeeCordChameleon.java
@@ -58,12 +58,18 @@ public final class BungeeCordChameleon extends Chameleon {
 	private final @NotNull BungeeCordUserManager userManager = new BungeeCordUserManager(this);
 	private final @NotNull BungeeCordScheduler scheduler = new BungeeCordScheduler(this);
 
-	public BungeeCordChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Plugin bungeePlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
+	BungeeCordChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Plugin bungeePlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
 		super(chameleonPlugin, pluginData, new ChameleonJavaLogger(bungeePlugin.getLogger()));
 		this.plugin = bungeePlugin;
 		this.audienceProvider = new BungeeCordAudienceProvider(this, bungeePlugin);
 		ProxyServer.getInstance().getPluginManager().registerListener(bungeePlugin, new BungeeCordListener(this));
 	}
+
+
+	public static @NotNull BungeeCordChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Plugin bungeePlugin, @NotNull PluginData pluginData) {
+		return new BungeeCordChameleonBootstrap(chameleonPlugin, bungeePlugin, pluginData);
+	}
+
 
 	@Override
 	public @NotNull ChameleonAudienceProvider getAdventure() {

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platforms/bungeecord/BungeeCordChameleonBootstrap.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platforms/bungeecord/BungeeCordChameleonBootstrap.java
@@ -1,0 +1,58 @@
+/*
+ * Chameleon Framework - Cross-platform Minecraft plugin framework
+ *  Copyright (c) 2021-present The Chameleon Framework Authors.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+package dev.hypera.chameleon.platforms.bungeecord;
+
+import dev.hypera.chameleon.core.ChameleonBootstrap;
+import dev.hypera.chameleon.core.ChameleonPlugin;
+import dev.hypera.chameleon.core.data.PluginData;
+import dev.hypera.chameleon.core.exceptions.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.logging.ChameleonLogger;
+import dev.hypera.chameleon.core.logging.impl.ChameleonJavaLogger;
+import net.md_5.bungee.api.plugin.Plugin;
+import org.jetbrains.annotations.NotNull;
+
+public final class BungeeCordChameleonBootstrap extends ChameleonBootstrap<BungeeCordChameleon> {
+
+    private final @NotNull Class<? extends ChameleonPlugin> chameleonPlugin;
+    private final @NotNull Plugin bungeePlugin;
+    private final @NotNull PluginData pluginData;
+
+    BungeeCordChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Plugin bungeePlugin, @NotNull PluginData pluginData) {
+        this.chameleonPlugin = chameleonPlugin;
+        this.bungeePlugin = bungeePlugin;
+        this.pluginData = pluginData;
+    }
+
+    @Override
+    public @NotNull BungeeCordChameleon loadInternal() throws ChameleonInstantiationException {
+        BungeeCordChameleon chameleon = new BungeeCordChameleon(chameleonPlugin, bungeePlugin, pluginData);
+        chameleon.onLoad();
+        return chameleon;
+    }
+
+    @Override
+    protected @NotNull ChameleonLogger createLogger() {
+        return new ChameleonJavaLogger(bungeePlugin.getLogger());
+    }
+
+}

--- a/platform-minestom/build.gradle.kts
+++ b/platform-minestom/build.gradle.kts
@@ -26,13 +26,8 @@ plugins {
 }
 
 repositories {
-    maven(url = "https://jitpack.io/") {
-        name = "jitpack"
-    }
-
-    maven(url = "https://repo.spongepowered.org/maven/") {
-        name = "sponge-powered"
-    }
+    maven("https://jitpack.io/")
+    maven("https://repo.spongepowered.org/maven/")
 }
 
 dependencies {

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platforms/minestom/MinestomChameleon.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platforms/minestom/MinestomChameleon.java
@@ -57,10 +57,14 @@ public final class MinestomChameleon extends Chameleon {
 	private final @NotNull MinestomUserManager userManager = new MinestomUserManager();
 	private final @NotNull MinestomScheduler scheduler = new MinestomScheduler();
 
-	public MinestomChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Extension extension, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
+	MinestomChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Extension extension, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
 		super(chameleonPlugin, pluginData, new ChameleonSlf4jLogger(extension.getLogger()));
 		this.extension = extension;
 		new MinestomListener(this);
+	}
+
+	public static @NotNull MinestomChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Extension extension, @NotNull PluginData pluginData) {
+		return new MinestomChameleonBootstrap(chameleonPlugin, extension, pluginData);
 	}
 
 

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platforms/minestom/MinestomChameleonBootstrap.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platforms/minestom/MinestomChameleonBootstrap.java
@@ -1,0 +1,58 @@
+/*
+ * Chameleon Framework - Cross-platform Minecraft plugin framework
+ *  Copyright (c) 2021-present The Chameleon Framework Authors.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+package dev.hypera.chameleon.platforms.minestom;
+
+import dev.hypera.chameleon.core.ChameleonBootstrap;
+import dev.hypera.chameleon.core.ChameleonPlugin;
+import dev.hypera.chameleon.core.data.PluginData;
+import dev.hypera.chameleon.core.exceptions.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.logging.ChameleonLogger;
+import dev.hypera.chameleon.core.logging.impl.ChameleonSlf4jLogger;
+import net.minestom.server.extensions.Extension;
+import org.jetbrains.annotations.NotNull;
+
+public final class MinestomChameleonBootstrap extends ChameleonBootstrap<MinestomChameleon> {
+
+    private final @NotNull Class<? extends ChameleonPlugin> chameleonPlugin;
+    private final @NotNull Extension extension;
+    private final @NotNull PluginData pluginData;
+
+    MinestomChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Extension extension, @NotNull PluginData pluginData) {
+        this.chameleonPlugin = chameleonPlugin;
+        this.extension = extension;
+        this.pluginData = pluginData;
+    }
+
+    @Override
+    public @NotNull MinestomChameleon loadInternal() throws ChameleonInstantiationException {
+        MinestomChameleon chameleon = new MinestomChameleon(chameleonPlugin, extension, pluginData);
+        chameleon.onLoad();
+        return chameleon;
+    }
+
+    @Override
+    protected @NotNull ChameleonLogger createLogger() {
+        return new ChameleonSlf4jLogger(extension.getLogger());
+    }
+
+}

--- a/platform-spigot/build.gradle.kts
+++ b/platform-spigot/build.gradle.kts
@@ -26,9 +26,7 @@ plugins {
 }
 
 repositories {
-    maven(url = "https://hub.spigotmc.org/nexus/content/repositories/snapshots/") {
-        name = "spigotmc"
-    }
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
 }
 
 dependencies {

--- a/platform-spigot/src/main/java/dev/hypera/chameleon/platforms/spigot/SpigotChameleon.java
+++ b/platform-spigot/src/main/java/dev/hypera/chameleon/platforms/spigot/SpigotChameleon.java
@@ -58,13 +58,16 @@ public final class SpigotChameleon extends Chameleon {
 	private final @NotNull SpigotUserManager userManager = new SpigotUserManager(this);
 	private final @NotNull SpigotScheduler scheduler = new SpigotScheduler(this);
 
-	public SpigotChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin spigotPlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
+	SpigotChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin spigotPlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
 		super(chameleonPlugin, pluginData, new ChameleonJavaLogger(spigotPlugin.getLogger()));
 		this.plugin = spigotPlugin;
 		this.audienceProvider = new SpigotAudienceProvider(this, spigotPlugin);
 		Bukkit.getPluginManager().registerEvents(new SpigotListener(this), plugin);
 	}
 
+	public static @NotNull SpigotChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin spigotPlugin, @NotNull PluginData pluginData) {
+		return new SpigotChameleonBootstrap(chameleonPlugin, spigotPlugin, pluginData);
+	}
 
 
 	@Override

--- a/platform-spigot/src/main/java/dev/hypera/chameleon/platforms/spigot/SpigotChameleonBootstrap.java
+++ b/platform-spigot/src/main/java/dev/hypera/chameleon/platforms/spigot/SpigotChameleonBootstrap.java
@@ -1,0 +1,58 @@
+/*
+ * Chameleon Framework - Cross-platform Minecraft plugin framework
+ *  Copyright (c) 2021-present The Chameleon Framework Authors.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+package dev.hypera.chameleon.platforms.spigot;
+
+import dev.hypera.chameleon.core.ChameleonBootstrap;
+import dev.hypera.chameleon.core.ChameleonPlugin;
+import dev.hypera.chameleon.core.data.PluginData;
+import dev.hypera.chameleon.core.exceptions.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.logging.ChameleonLogger;
+import dev.hypera.chameleon.core.logging.impl.ChameleonJavaLogger;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+
+public final class SpigotChameleonBootstrap extends ChameleonBootstrap<SpigotChameleon> {
+
+    private final @NotNull Class<? extends ChameleonPlugin> chameleonPlugin;
+    private final @NotNull JavaPlugin spigotPlugin;
+    private final @NotNull PluginData pluginData;
+
+    SpigotChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin spigotPlugin, @NotNull PluginData pluginData) {
+        this.chameleonPlugin = chameleonPlugin;
+        this.spigotPlugin = spigotPlugin;
+        this.pluginData = pluginData;
+    }
+
+    @Override
+    protected @NotNull SpigotChameleon loadInternal() throws ChameleonInstantiationException {
+        SpigotChameleon chameleon = new SpigotChameleon(chameleonPlugin, spigotPlugin, pluginData);
+        chameleon.onLoad();
+        return chameleon;
+    }
+
+    @Override
+    protected @NotNull ChameleonLogger createLogger() {
+        return new ChameleonJavaLogger(spigotPlugin.getLogger());
+    }
+
+}

--- a/platform-velocity/build.gradle.kts
+++ b/platform-velocity/build.gradle.kts
@@ -25,9 +25,7 @@ plugins {
 }
 
 repositories {
-    maven(url = "https://nexus.velocitypowered.com/repository/maven-public/") {
-        name = "velocity"
-    }
+    maven("https://nexus.velocitypowered.com/repository/maven-public/")
 }
 
 dependencies {

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platforms/velocity/VelocityChameleon.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platforms/velocity/VelocityChameleon.java
@@ -46,7 +46,7 @@ import org.jetbrains.annotations.NotNull;
 /**
  * Velocity Chameleon
  */
-public class VelocityChameleon extends Chameleon {
+public final class VelocityChameleon extends Chameleon {
 
 	private final @NotNull VelocityPlugin plugin;
 	private final @NotNull VelocityAudienceProvider audienceProvider = new VelocityAudienceProvider(this);
@@ -56,11 +56,16 @@ public class VelocityChameleon extends Chameleon {
 	private final @NotNull VelocityUserManager userManager = new VelocityUserManager(this);
 	private final @NotNull VelocityScheduler scheduler = new VelocityScheduler(this);
 
-	public VelocityChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull VelocityPlugin velocityPlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
+	VelocityChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull VelocityPlugin velocityPlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
 		super(chameleonPlugin, pluginData, new ChameleonSlf4jLogger(velocityPlugin.getLogger()));
 		this.plugin = velocityPlugin;
 		this.plugin.getServer().getEventManager().register(plugin, new VelocityListener(this));
 	}
+
+	public static @NotNull VelocityChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull VelocityPlugin velocityPlugin, @NotNull PluginData pluginData) {
+		return new VelocityChameleonBootstrap(chameleonPlugin, velocityPlugin, pluginData);
+	}
+
 
 	@Override
 	public @NotNull ChameleonAudienceProvider getAdventure() {

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platforms/velocity/VelocityChameleonBootstrap.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platforms/velocity/VelocityChameleonBootstrap.java
@@ -1,0 +1,57 @@
+/*
+ * Chameleon Framework - Cross-platform Minecraft plugin framework
+ *  Copyright (c) 2021-present The Chameleon Framework Authors.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ */
+package dev.hypera.chameleon.platforms.velocity;
+
+import dev.hypera.chameleon.core.ChameleonBootstrap;
+import dev.hypera.chameleon.core.ChameleonPlugin;
+import dev.hypera.chameleon.core.data.PluginData;
+import dev.hypera.chameleon.core.exceptions.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.core.logging.ChameleonLogger;
+import dev.hypera.chameleon.core.logging.impl.ChameleonSlf4jLogger;
+import org.jetbrains.annotations.NotNull;
+
+public final class VelocityChameleonBootstrap extends ChameleonBootstrap<VelocityChameleon> {
+
+    private final @NotNull Class<? extends ChameleonPlugin> chameleonPlugin;
+    private final @NotNull VelocityPlugin velocityPlugin;
+    private final @NotNull PluginData pluginData;
+
+    VelocityChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull VelocityPlugin velocityPlugin, @NotNull PluginData pluginData) {
+        this.chameleonPlugin = chameleonPlugin;
+        this.velocityPlugin = velocityPlugin;
+        this.pluginData = pluginData;
+    }
+
+    @Override
+    protected @NotNull VelocityChameleon loadInternal() throws ChameleonInstantiationException {
+        VelocityChameleon chameleon = new VelocityChameleon(chameleonPlugin, velocityPlugin, pluginData);
+        chameleon.onLoad();
+        return chameleon;
+    }
+
+    @Override
+    protected @NotNull ChameleonLogger createLogger() {
+        return new ChameleonSlf4jLogger(velocityPlugin.getLogger());
+    }
+
+}


### PR DESCRIPTION
This pull request adds bootstrapping to Chameleon, this allows plugins to do things like runtime dependency loading before Chameleon is actually loaded.

**This breaks the current method of loading Chameleon**!
Chameleon now has to be loaded using: `<Platform>Chameleon#create(ChameleonPlugin.class, this, PluginData).load()`

Before this is merged, [Example #7](https://github.com/ChameleonFramework/Example/pull/7) should be merged.