### PR TITLE
fix(velocity): register event listener in onEnable

### DIFF
--- a/api/src/test/java/dev/hypera/chameleon/extensions/ExtensionTests.java
+++ b/api/src/test/java/dev/hypera/chameleon/extensions/ExtensionTests.java
@@ -35,7 +35,7 @@ final class ExtensionTests {
 
     @Test
     void invalidCatch() {
-        Assertions.assertDoesNotThrow(TestPlatformExtension::new);
+        assertDoesNotThrow(TestPlatformExtension::new);
         assertThrows(IllegalStateException.class, TestInvalidPlatformExtension::new);
     }
 

--- a/api/src/test/java/dev/hypera/chameleon/extensions/ExtensionTests.java
+++ b/api/src/test/java/dev/hypera/chameleon/extensions/ExtensionTests.java
@@ -28,7 +28,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import dev.hypera.chameleon.extensions.objects.TestInvalidPlatformExtension;
 import dev.hypera.chameleon.extensions.objects.TestPlatformExtension;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class ExtensionTests {

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/VelocityChameleon.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/VelocityChameleon.java
@@ -63,7 +63,6 @@ public final class VelocityChameleon extends Chameleon {
     VelocityChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Collection<ChameleonExtension<?>> extensions, @NotNull VelocityPlugin velocityPlugin, @NotNull PluginData pluginData) throws ChameleonInstantiationException {
         super(chameleonPlugin, extensions, pluginData, new ChameleonSlf4jLogger(velocityPlugin.getLogger()));
         this.plugin = velocityPlugin;
-        this.plugin.getServer().getEventManager().register(this.plugin, new VelocityListener(this));
     }
 
     /**
@@ -79,6 +78,14 @@ public final class VelocityChameleon extends Chameleon {
         return new VelocityChameleonBootstrap(chameleonPlugin, velocityPlugin, pluginData);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void onEnable() {
+        this.plugin.getServer().getEventManager().register(this.plugin, new VelocityListener(this));
+        super.onEnable();
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
Register Velocity event listener in the onEnable method to allow Chameleon to be loaded in the plugin's constructor.
