### PR TITLE
chore(deps): update indra to v3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ version = "1.0"
 # Kyori
 adventure = "4.11.0"
 adventure-platform = "4.1.2"
-indra = "2.2.0"
+indra = "3.0.0"
 
 # Platforms
 platform-bukkit = "1.19-R0.1-SNAPSHOT"

--- a/platform-bungeecord/build.gradle.kts
+++ b/platform-bungeecord/build.gradle.kts
@@ -21,15 +21,13 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-import net.kyori.indra.repository.sonatypeSnapshots
-
 plugins {
     id("chameleon.common")
     id("java-library")
 }
 
 repositories {
-    sonatypeSnapshots()
+    sonatype.ossSnapshots()
 }
 
 dependencies {


### PR DESCRIPTION
**Summary**
Update `net.kyori:indra*` to `3.0.0` and adapt to breaking changes.

**Changes**
 - Update `indra` to `3.0.0`
 - `sonatypeSnapshots()` -> `sonatype.ossSnapshots()`

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
