### PR TITLE
refactor(api)!: switch to PlatformTarget instead of static enums, repackage and overall clean up

### DIFF
--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/Generator.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/Generator.java
@@ -28,10 +28,8 @@ import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import dev.hypera.chameleon.annotations.Plugin;
-import dev.hypera.chameleon.annotations.Plugin.Platform;
 import dev.hypera.chameleon.data.PluginData;
 import java.util.Arrays;
-import java.util.stream.Collectors;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.TypeElement;
 import org.jetbrains.annotations.ApiStatus.NonExtendable;
@@ -59,7 +57,7 @@ public abstract class Generator {
 
     protected @NotNull CodeBlock createPluginData(@NotNull Plugin data) {
         return CodeBlock.builder().add(
-            "$T pluginData = new $T($S, $S, $S, $S, $T.asList($L), $T.asList($L))",
+            "$T pluginData = new $T($S, $S, $S, $S, $T.asList($L))",
             PluginData.class,
             PluginData.class,
             data.name().isEmpty() ? (data.id().isEmpty() ? "Unknown" : data.id()) : data.name(),
@@ -67,9 +65,7 @@ public abstract class Generator {
             data.description(),
             data.url(),
             Arrays.class,
-            data.authors().length > 0 ? '"' + String.join("\",\"", data.authors()) + '"' : "",
-            Arrays.class,
-            CodeBlock.builder().add(Arrays.stream(data.platforms().length > 0 ? data.platforms() : Platform.values()).map(p -> "$1T." + p.name()).collect(Collectors.joining(", ")), PluginData.Platform.class).build()
+            data.authors().length > 0 ? '"' + String.join("\",\"", data.authors()) + '"' : ""
         ).build();
     }
 

--- a/api/src/main/java/dev/hypera/chameleon/command/Command.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/Command.java
@@ -21,15 +21,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands;
+package dev.hypera.chameleon.command;
 
-import dev.hypera.chameleon.commands.annotations.CommandHandler;
-import dev.hypera.chameleon.commands.annotations.Permission;
-import dev.hypera.chameleon.commands.annotations.SubCommandHandler;
-import dev.hypera.chameleon.commands.context.Context;
-import dev.hypera.chameleon.commands.objects.Condition;
-import dev.hypera.chameleon.commands.objects.Platform;
+import dev.hypera.chameleon.command.annotations.CommandHandler;
+import dev.hypera.chameleon.command.annotations.Permission;
+import dev.hypera.chameleon.command.annotations.SubCommandHandler;
+import dev.hypera.chameleon.command.context.Context;
+import dev.hypera.chameleon.command.objects.Condition;
 import dev.hypera.chameleon.exceptions.command.ChameleonCommandException;
+import dev.hypera.chameleon.platform.PlatformTarget;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -55,7 +55,7 @@ public abstract class Command {
     private final @NotNull Set<SubCommand> subCommands = new HashSet<>();
     private final @Nullable Permission permission;
 
-    private @NotNull Platform platform = Platform.ALL;
+    private @NotNull PlatformTarget platform = PlatformTarget.all();
     private @NotNull List<Condition> conditions = new ArrayList<>();
     private @Nullable Component permissionErrorMessage;
 
@@ -199,20 +199,20 @@ public abstract class Command {
     }
 
     /**
-     * Get command {@link Platform}.
+     * Get the platform target of this command.
      *
-     * @return command {@link Platform}.
+     * @return platform target.
      */
-    public final @NotNull Platform getPlatform() {
+    public final @NotNull PlatformTarget getPlatform() {
         return this.platform;
     }
 
     /**
-     * Set command {@link Platform}.
+     * Set the platform target of this command.
      *
-     * @param platform Command {@link Platform}.
+     * @param platform platform target.
      */
-    protected final void setPlatform(@NotNull Platform platform) {
+    protected final void setPlatform(@NotNull PlatformTarget platform) {
         this.platform = platform;
     }
 

--- a/api/src/main/java/dev/hypera/chameleon/command/SubCommand.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/SubCommand.java
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands;
+package dev.hypera.chameleon.command;
 
-import dev.hypera.chameleon.commands.annotations.Permission;
-import dev.hypera.chameleon.commands.context.Context;
+import dev.hypera.chameleon.command.annotations.Permission;
+import dev.hypera.chameleon.command.context.Context;
 import dev.hypera.chameleon.exceptions.command.ChameleonCommandException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/api/src/main/java/dev/hypera/chameleon/command/annotations/CommandHandler.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/annotations/CommandHandler.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.annotations;
+package dev.hypera.chameleon.command.annotations;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/api/src/main/java/dev/hypera/chameleon/command/annotations/Permission.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/annotations/Permission.java
@@ -21,45 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.users.platforms;
+package dev.hypera.chameleon.command.annotations;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.platform.proxy.ProxyPlatform;
-import dev.hypera.chameleon.platform.proxy.Server;
-import dev.hypera.chameleon.users.User;
-import java.util.Optional;
-import java.util.function.BiConsumer;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * In-game {@link User} on a {@link ProxyPlatform}.
- *
- * @see ProxyPlatform
+ * Permission.
  */
-@PlatformSpecific(Platform.Type.PROXY)
-public interface ProxyUser extends User {
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Permission {
 
     /**
-     * Get the {@link Server} this user is currently on.
+     * Get permission string.
      *
-     * @return optionally the {@link Server} this user is currently on, if available, otherwise empty.
+     * @return permission string.
      */
-    @NotNull Optional<Server> getServer();
-
-    /**
-     * Attempt to switch this user to the given {@link Server}.
-     *
-     * @param server {@link Server} to switch this user to.
-     */
-    void connect(@NotNull Server server);
-
-    /**
-     * Attempt to switch this user to the given {@link Server} and then run the given callback.
-     *
-     * @param server   {@link Server} to switch this user to.
-     * @param callback Callback to run afterwards.
-     */
-    void connect(@NotNull Server server, @NotNull BiConsumer<Boolean, Throwable> callback);
+    @NotNull String value();
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/command/annotations/SubCommandHandler.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/annotations/SubCommandHandler.java
@@ -21,22 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.users.permissions;
+package dev.hypera.chameleon.command.annotations;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Permission holder.
+ * Sub-command handler annotation.
  */
-public interface PermissionHolder {
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SubCommandHandler {
 
     /**
-     * Checks whether this {@link PermissionHolder} has the given permission.
+     * Get sub-command names, separated by '|'.
      *
-     * @param permission Permission to check for.
-     *
-     * @return {@code true} if the {@link PermissionHolder} has the given permission, otherwise {@code false}.
+     * @return sub-command names.
      */
-    boolean hasPermission(@NotNull String permission);
+    @NotNull String value();
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/command/context/Context.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/context/Context.java
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.context;
+package dev.hypera.chameleon.command.context;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.users.ChatUser;
 import org.jetbrains.annotations.NotNull;
 

--- a/api/src/main/java/dev/hypera/chameleon/command/context/ContextImpl.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/context/ContextImpl.java
@@ -21,26 +21,58 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.annotations;
+package dev.hypera.chameleon.command.context;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import dev.hypera.chameleon.Chameleon;
+import dev.hypera.chameleon.users.ChatUser;
+import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Sub-command handler annotation.
+ * {@link Context} implementation.
  */
-@Target(ElementType.METHOD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface SubCommandHandler {
+public final class ContextImpl implements Context {
+
+    private final @NotNull ChatUser sender;
+    private final @NotNull Chameleon chameleon;
+    private final @NotNull String[] args;
 
     /**
-     * Get sub-command names, separated by '|'.
+     * {@link ContextImpl} constructor.
      *
-     * @return sub-command names.
+     * @param sender Command sender.
+     * @param chameleon {@link Chameleon} instance.
+     * @param args Command arguments.
      */
-    @NotNull String value();
+    @Internal
+    public ContextImpl(@NotNull ChatUser sender, @NotNull Chameleon chameleon, @NotNull String[] args) {
+        this.sender = sender;
+        this.chameleon = chameleon;
+        this.args = args;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull ChatUser getSender() {
+        return this.sender;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Chameleon getChameleon() {
+        return this.chameleon;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String[] getArgs() {
+        return this.args;
+    }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/command/objects/Condition.java
+++ b/api/src/main/java/dev/hypera/chameleon/command/objects/Condition.java
@@ -21,10 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.objects;
+package dev.hypera.chameleon.command.objects;
 
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.Context;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.Context;
 import java.util.Optional;
 import java.util.function.Function;
 import net.kyori.adventure.text.Component;

--- a/api/src/main/java/dev/hypera/chameleon/data/PluginData.java
+++ b/api/src/main/java/dev/hypera/chameleon/data/PluginData.java
@@ -36,7 +36,6 @@ public class PluginData {
     private final @NotNull String description;
     private final @NotNull String url;
     private final @NotNull List<String> authors;
-    private final @NotNull List<Platform> platforms;
 
     /**
      * {@link PluginData} constructor.
@@ -46,15 +45,13 @@ public class PluginData {
      * @param description Plugin description.
      * @param url         Plugin url.
      * @param authors     Plugin authors.
-     * @param platforms   Plugin {@link Platform}s.
      */
-    public PluginData(@NotNull String name, @NotNull String version, @NotNull String description, @NotNull String url, @NotNull List<String> authors, @NotNull List<Platform> platforms) {
+    public PluginData(@NotNull String name, @NotNull String version, @NotNull String description, @NotNull String url, @NotNull List<String> authors) {
         this.name = name;
         this.version = version;
         this.description = description;
         this.url = url;
         this.authors = authors;
-        this.platforms = platforms;
     }
 
     /**
@@ -100,22 +97,6 @@ public class PluginData {
      */
     public @NotNull List<String> getAuthors() {
         return this.authors;
-    }
-
-    /**
-     * Get plugin {@link Platform}s.
-     *
-     * @return plugin {@link Platform}s.
-     */
-    public @NotNull List<Platform> getPlatforms() {
-        return this.platforms;
-    }
-
-    /**
-     * Platform.
-     */
-    public enum Platform {
-        BUKKIT, BUNGEECORD, MINESTOM, NUKKIT, SPONGE, VELOCITY
     }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/events/proxy/ProxyUserEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/events/proxy/ProxyUserEvent.java
@@ -23,16 +23,13 @@
  */
 package dev.hypera.chameleon.events.proxy;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
 import dev.hypera.chameleon.events.common.UserEvent;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Proxy-only event.
  */
-@PlatformSpecific(Platform.Type.PROXY)
 public interface ProxyUserEvent extends UserEvent {
 
     /**

--- a/api/src/main/java/dev/hypera/chameleon/events/proxy/ProxyUserSwitchEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/events/proxy/ProxyUserSwitchEvent.java
@@ -23,10 +23,8 @@
  */
 package dev.hypera.chameleon.events.proxy;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
 import dev.hypera.chameleon.platform.proxy.Server;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.util.Optional;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
@@ -35,7 +33,6 @@ import org.jetbrains.annotations.Nullable;
 /**
  * {@link ProxyUser} switch sever event, dispatched whenever a player switches server.
  */
-@PlatformSpecific(Platform.Type.PROXY)
 public final class ProxyUserSwitchEvent implements ProxyUserEvent {
 
     private final @NotNull ProxyUser user;

--- a/api/src/main/java/dev/hypera/chameleon/events/server/ServerUserEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/events/server/ServerUserEvent.java
@@ -23,16 +23,13 @@
  */
 package dev.hypera.chameleon.events.server;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
 import dev.hypera.chameleon.events.common.UserEvent;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Server-only event.
  */
-@PlatformSpecific(Platform.Type.SERVER)
 public interface ServerUserEvent extends UserEvent {
 
     /**

--- a/api/src/main/java/dev/hypera/chameleon/events/server/ServerUserKickEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/events/server/ServerUserKickEvent.java
@@ -23,9 +23,7 @@
  */
 package dev.hypera.chameleon.events.server;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +32,6 @@ import org.jetbrains.annotations.Nullable;
 /**
  * {@link ServerUser} kick event, dispatched when a user is kicked from the server.
  */
-@PlatformSpecific(Platform.Type.SERVER)
 public final class ServerUserKickEvent implements ServerUserEvent {
 
     private final @NotNull ServerUser user;

--- a/api/src/main/java/dev/hypera/chameleon/managers/CommandManager.java
+++ b/api/src/main/java/dev/hypera/chameleon/managers/CommandManager.java
@@ -24,8 +24,7 @@
 package dev.hypera.chameleon.managers;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.objects.Platform;
+import dev.hypera.chameleon.command.Command;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
@@ -52,7 +51,7 @@ public abstract class CommandManager {
      * @param command {@link Command} to be registered.
      */
     public void register(@NotNull Command command) {
-        if (command.getPlatform().equals(Platform.ALL) || command.getPlatform().name().equals(this.chameleon.getPlatform().getType().name())) {
+        if (command.getPlatform().matches(this.chameleon.getPlatform())) {
             registerCommand(command);
         }
     }
@@ -63,7 +62,7 @@ public abstract class CommandManager {
      * @param command {@link Command} to be unregistered.
      */
     public void unregister(@NotNull Command command) {
-        if (command.getPlatform().equals(Platform.ALL) || command.getPlatform().name().equals(this.chameleon.getPlatform().getType().name())) {
+        if (command.getPlatform().matches(this.chameleon.getPlatform())) {
             unregisterCommand(command);
         }
     }

--- a/api/src/main/java/dev/hypera/chameleon/managers/PluginManager.java
+++ b/api/src/main/java/dev/hypera/chameleon/managers/PluginManager.java
@@ -24,7 +24,7 @@
 package dev.hypera.chameleon.managers;
 
 import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import java.util.Optional;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;

--- a/api/src/main/java/dev/hypera/chameleon/platform/Platform.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/Platform.java
@@ -23,80 +23,48 @@
  */
 package dev.hypera.chameleon.platform;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.proxy.ProxyPlatform;
-import dev.hypera.chameleon.platform.server.ServerPlatform;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Platform.
+ * Represents a proxy or server platform.
  */
-public abstract class Platform {
+public interface Platform {
 
     /**
-     * Get API name.
+     * Create a new Platform target.
+     * <p>This allows you to target a certain Platform or restrict a feature to a certain Platform.</p>
      *
-     * @return API name.
-     */
-    public abstract @NotNull String getAPIName();
-
-    /**
-     * Get name.
+     * @param id Target Platform identifier.
      *
-     * @return name.
+     * @return new Platform target.
      */
-    public abstract @NotNull String getName();
-
-    /**
-     * Get version.
-     *
-     * @return version.
-     */
-    public abstract @NotNull String getVersion();
-
-    /**
-     * Get {@link Type}.
-     *
-     * @return {@link Type}.
-     */
-    public abstract @NotNull Type getType();
-
-
-    /**
-     * Cast this {@link Platform} instance to an {@link ProxyPlatform} instance.
-     *
-     * @return {@link ProxyPlatform}.
-     * @throws IllegalStateException if this {@link Platform} is not an {@link ProxyPlatform}.
-     */
-    @PlatformSpecific(Type.PROXY)
-    public final @NotNull ProxyPlatform proxy() {
-        if (this instanceof ProxyPlatform) {
-            return (ProxyPlatform) this;
-        } else {
-            throw new IllegalStateException("Cannot cast to ProxyPlatform");
-        }
+    static @NotNull PlatformTarget target(@NotNull String id) {
+        return PlatformTarget.id(id);
     }
 
-    /**
-     * Cast this {@link Platform} instance to an {@link ServerPlatform} instance.
-     *
-     * @return {@link ServerPlatform}.
-     * @throws IllegalStateException if this {@link Platform} is not an {@link ServerPlatform}.
-     */
-    @PlatformSpecific(Type.SERVER)
-    public final @NotNull ServerPlatform server() {
-        if (this instanceof ServerPlatform) {
-            return (ServerPlatform) this;
-        } else {
-            throw new IllegalStateException("Cannot cast to ServerPlatform");
-        }
-    }
 
     /**
-     * Platform type.
+     * Get a unique identifier for this Platform.
+     * <p>This will return the common name of the API that is in use, e.g. "BungeeCord" or "Velocity".</p>
+     *
+     * @return Platform identifier.
      */
-    public enum Type {
-        SERVER, PROXY
-    }
+    @NotNull String getId();
+
+    /**
+     * Get the friendly name of this Platform.
+     * <p>This will return the name provided by the Platform, which may not match the name of the API that is in use.</p>
+     *
+     * @return Platform friendly name.
+     */
+    @NotNull String getName();
+
+    /**
+     * Get the version of this Platform.
+     * <p>This will return the version provided by the Platform.</p>
+     *
+     * @return Platform version.
+     */
+    @NotNull String getVersion();
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/platform/PlatformPlugin.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/PlatformPlugin.java
@@ -21,9 +21,8 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.platform.objects;
+package dev.hypera.chameleon.platform;
 
-import dev.hypera.chameleon.platform.Platform;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -32,76 +31,77 @@ import org.jetbrains.annotations.ApiStatus.Experimental;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * {@link Platform} plugin.
+ * Represents a plugin running on the platform.
  */
 public interface PlatformPlugin {
 
     /**
-     * Get {@link PlatformPlugin} name.
+     * Get the name of this plugin.
      *
-     * @return {@link PlatformPlugin} name.
+     * @return name.
      */
     @NotNull String getName();
 
     /**
-     * Get {@link PlatformPlugin} version.
+     * Get the version of this plugin.
      *
-     * @return {@link PlatformPlugin} version.
+     * @return version.
      */
     @NotNull String getVersion();
 
     /**
-     * Get {@link PlatformPlugin} description.
+     * Get the description of this plugin.
      *
-     * @return optionally {@link PlatformPlugin} description.
+     * @return an {@code Optional} containing the plugin description, if available, otherwise an
+     *     empty optional.
      */
     @NotNull Optional<String> getDescription();
 
     /**
-     * Get {@link PlatformPlugin} main class.
+     * Get the main class of this plugin.
      *
-     * @return {@link PlatformPlugin} main class.
+     * @return main class.
      */
     @NotNull Class<?> getMainClass();
 
     /**
-     * Get {@link PlatformPlugin} authors.
+     * Get the authors of this plugin.
      *
-     * @return {@link PlatformPlugin} authors.
+     * @return authors.
      */
     @NotNull List<String> getAuthors();
 
     /**
-     * Get {@link PlatformPlugin} required dependencies.
+     * Get the required dependencies of this plugin.
      *
-     * @return {@link PlatformPlugin} required dependencies.
+     * @return required dependencies.
      */
     @NotNull Set<String> getDependencies();
 
     /**
-     * Get {@link PlatformPlugin} optional dependencies.
+     * Get the optional dependencies of this plugin.
      *
-     * @return {@link PlatformPlugin} optional dependencies.
+     * @return optional dependencies.
      */
     @NotNull Set<String> getSoftDependencies();
 
     /**
-     * Get {@link PlatformPlugin} data folder.
+     * Get the data folder of this plugin.
      *
-     * @return {@link PlatformPlugin} data folder.
+     * @return data folder.
      */
     @NotNull Path getDataFolder();
 
     /**
-     * Attempt to enable the {@link PlatformPlugin}.
-     * May not work on some platforms.
+     * Attempt to enable this plugin.
+     * <p>This is not guaranteed to work and is currently experimental. Use at your own risk!</p>
      */
     @Experimental
     void enable();
 
     /**
-     * Attempt to disable the {@link PlatformPlugin}.
-     * May not work on some platforms.
+     * Attempt to disable this plugin.
+     * <p>This is not guaranteed to work and is currently experimental. Use at your own risk!</p>
      */
     @Experimental
     void disable();

--- a/api/src/main/java/dev/hypera/chameleon/platform/PlatformTarget.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/PlatformTarget.java
@@ -1,0 +1,99 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2022 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform;
+
+import dev.hypera.chameleon.platform.proxy.ProxyPlatform;
+import dev.hypera.chameleon.platform.server.ServerPlatform;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * {@link Platform} target.
+ * <p>This allows you to target a certain platform or restrict a feature to a certain platform.</p>
+ */
+public interface PlatformTarget {
+
+    /**
+     * Create a new platform target that matches all platforms.
+     *
+     * @return new platform target.
+     */
+    static @NotNull PlatformTarget all() {
+        return new PlatformTargetImpl("all", p -> true);
+    }
+
+    /**
+     * Create a new platform target that matches nothing.
+     *
+     * @return new platform target.
+     */
+    static @NotNull PlatformTarget none() {
+        return new PlatformTargetImpl("none", p -> false);
+    }
+
+    /**
+     * Create a new platform target that matches all proxy platforms.
+     *
+     * @return new platform target.
+     */
+    static @NotNull PlatformTarget proxy() {
+        return new PlatformTargetImpl("proxy", p -> p instanceof ProxyPlatform);
+    }
+
+    /**
+     * Create a new platform target that matches all server platforms.
+     *
+     * @return new platform target.
+     */
+    static @NotNull PlatformTarget server() {
+        return new PlatformTargetImpl("server", p -> p instanceof ServerPlatform);
+    }
+
+    /**
+     * Create a new platform target that matches platforms with the given {@code id}.
+     *
+     * @param id Target platform identifier.
+     *
+     * @return new platform target.
+     */
+    static @NotNull PlatformTarget id(@NotNull String id) {
+        return new PlatformTargetImpl(id, p -> p.getId().equalsIgnoreCase(id));
+    }
+
+    /**
+     * Get the target platform identifier.
+     *
+     * @return target identifier.
+     */
+    @NotNull String getId();
+
+    /**
+     * Check if the given platform matches this target.
+     *
+     * @param platform Platform.
+     *
+     * @return {@code true} if the given platform matches this target, otherwise {@code false}.
+     */
+    boolean matches(@NotNull Platform platform);
+
+}

--- a/api/src/main/java/dev/hypera/chameleon/platform/PlatformTargetImpl.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/PlatformTargetImpl.java
@@ -21,26 +21,57 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.annotations;
+package dev.hypera.chameleon.platform;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import java.util.Objects;
+import java.util.function.Predicate;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Permission.
+ * {@link PlatformTarget} implementation.
  */
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.RUNTIME)
-public @interface Permission {
+final class PlatformTargetImpl implements PlatformTarget {
+
+    private final @NotNull String id;
+    private final @NotNull Predicate<Platform> matcher;
+
+    PlatformTargetImpl(@NotNull String id, @NotNull Predicate<Platform> matcher) {
+        this.id = id;
+        this.matcher = matcher;
+    }
 
     /**
-     * Get permission string.
-     *
-     * @return permission string.
+     * {@inheritDoc}
      */
-    @NotNull String value();
+    @Override
+    public @NotNull String getId() {
+        return this.id;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean matches(@NotNull Platform platform) {
+        return this.matcher.test(platform);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (null == obj || getClass() != obj.getClass()) {
+            return false;
+        }
+
+        return this.id.equals(((PlatformTargetImpl) obj).id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/platform/proxy/ProxyPlatform.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/proxy/ProxyPlatform.java
@@ -23,32 +23,30 @@
  */
 package dev.hypera.chameleon.platform.proxy;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
 import dev.hypera.chameleon.platform.Platform;
 import java.util.Optional;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Proxy {@link Platform}.
+ * Represents a proxy platform.
  */
-@PlatformSpecific(Platform.Type.PROXY)
-public abstract class ProxyPlatform extends Platform {
+public interface ProxyPlatform extends Platform {
 
     /**
-     * Get {@link Server}s.
+     * Get the "sub-servers" configured in this Proxy.
      *
-     * @return set of {@link Server}s.
+     * @return all "sub-servers".
      */
-    public abstract @NotNull Set<Server> getServers();
+    @NotNull Set<Server> getServers();
 
     /**
-     * Attempt to find {@link Server} by name.
+     * Attempt to find a "sub-server" by the name or identifier it has.
      *
      * @param name The name to search for.
      *
-     * @return {@link Optional} containing the {@link Server} if found, otherwise empty.
+     * @return an {@code Optional} containing the server, if found, otherwise an empty optional.
      */
-    public abstract @NotNull Optional<Server> getServer(@NotNull String name);
+    @NotNull Optional<Server> getServer(@NotNull String name);
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/platform/proxy/Server.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/proxy/Server.java
@@ -23,42 +23,39 @@
  */
 package dev.hypera.chameleon.platform.proxy;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.net.SocketAddress;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * {@link ProxyPlatform} sub-server.
+ * Represents a "sub-server" behind a proxy platform.
  */
-@PlatformSpecific(Platform.Type.PROXY)
 public interface Server {
 
     /**
-     * Get {@link Server} name.
+     * Get the name of this server.
      *
-     * @return {@link Server} name.
+     * @return  name.
      */
     @NotNull String getName();
 
     /**
-     * Get {@link Server} socket address.
+     * Get the socket address of this server.
      *
-     * @return {@link Server} socket address.
+     * @return socket address.
      */
     @NotNull SocketAddress getSocketAddress();
 
     /**
-     * Get all {@link ProxyUser}s on this {@link Server}.
+     * Get all proxy users currently connected to this server.
      *
-     * @return set of {@link ProxyUser} currently on this {@link Server}.
+     * @return players connected to this server.
      */
     @NotNull Set<ProxyUser> getPlayers();
 
     /**
-     * Send a plugin message to this {@link Server}.
+     * Send a plugin message to this server.
      *
      * @param channel Plugin message channel.
      * @param data    Data.

--- a/api/src/main/java/dev/hypera/chameleon/platform/server/GameMode.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/server/GameMode.java
@@ -23,14 +23,9 @@
  */
 package dev.hypera.chameleon.platform.server;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.platforms.ServerUser;
-
 /**
- * {@link ServerUser} Game mode.
+ * {@link dev.hypera.chameleon.users.ServerUser} Game mode.
  */
-@PlatformSpecific(Platform.Type.SERVER)
 public enum GameMode {
 
     SURVIVAL, CREATIVE, ADVENTURE, SPECTATOR

--- a/api/src/main/java/dev/hypera/chameleon/platform/server/ServerPlatform.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/server/ServerPlatform.java
@@ -23,13 +23,11 @@
  */
 package dev.hypera.chameleon.platform.server;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
 import dev.hypera.chameleon.platform.Platform;
 
 /**
- * Server {@link Platform}.
+ * Represents a server platform.
  */
-@PlatformSpecific(Platform.Type.SERVER)
-public abstract class ServerPlatform extends Platform {
+public interface ServerPlatform extends Platform {
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/users/ChatUser.java
+++ b/api/src/main/java/dev/hypera/chameleon/users/ChatUser.java
@@ -23,76 +23,30 @@
  */
 package dev.hypera.chameleon.users;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
-import dev.hypera.chameleon.users.permissions.PermissionHolder;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
-import dev.hypera.chameleon.users.platforms.ServerUser;
 import net.kyori.adventure.audience.Audience;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * A chat-receiving user, this could either be an actual player or console.
+ * Represents something that can receive messages.
+ * <p>This could either be an actual player using the Minecraft client, or the platform
+ * Console.</p>
  */
 public interface ChatUser extends Audience, PermissionHolder {
 
     /**
-     * Get this user's name.
+     * Get the name of this user.
      *
-     * @return user's name.
+     * @return name.
      */
     @NotNull String getName();
 
     /**
-     * Whether the player can click chat messages.
+     * Get whether this user can interact with chat messages.
+     * <p>An example usage of this would be checking if a user can click on a chat message, and if
+     * so use a click event for a link, otherwise just display the link.</p>
      *
-     * @return true if the player can click chat messages.
+     * @return {@code true} if this user can interact with chat, otherwise {@code false}.
      */
     boolean hasInteractiveChat();
-
-
-    /**
-     * Cast this {@link ChatUser} instance to an {@link User} instance.
-     *
-     * @return {@link User}.
-     * @throws IllegalStateException if this {@link ChatUser} is not an {@link User}.
-     */
-    default @NotNull User user() {
-        if (this instanceof User) {
-            return (User) this;
-        } else {
-            throw new IllegalStateException("Cannot cast to User");
-        }
-    }
-
-    /**
-     * Cast this {@link ChatUser} instance to an {@link ProxyUser} instance.
-     *
-     * @return {@link ProxyUser}.
-     * @throws IllegalStateException if this {@link ChatUser} is not an {@link ProxyUser}.
-     */
-    @PlatformSpecific(Platform.Type.PROXY)
-    default @NotNull ProxyUser proxy() {
-        if (this instanceof ProxyUser) {
-            return (ProxyUser) this;
-        } else {
-            throw new IllegalStateException("Cannot cast to ProxyUser");
-        }
-    }
-
-    /**
-     * Cast this {@link ChatUser} instance to an {@link ServerUser} instance.
-     *
-     * @return {@link ServerUser}.
-     * @throws IllegalStateException if this {@link ChatUser} is not an {@link ServerUser}.
-     */
-    @PlatformSpecific(Platform.Type.SERVER)
-    default @NotNull ServerUser server() {
-        if (this instanceof ServerUser) {
-            return (ServerUser) this;
-        } else {
-            throw new IllegalStateException("Cannot cast to ServerUser");
-        }
-    }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/users/PermissionHolder.java
+++ b/api/src/main/java/dev/hypera/chameleon/users/PermissionHolder.java
@@ -21,37 +21,23 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.platform.sponge.managers;
+package dev.hypera.chameleon.users;
 
-import dev.hypera.chameleon.managers.PluginManager;
-import dev.hypera.chameleon.platform.PlatformPlugin;
-import dev.hypera.chameleon.platform.sponge.platform.plugin.SpongePlugin;
-import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
-import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
-import org.spongepowered.api.Sponge;
 
 /**
- * Sponge {@link PluginManager} implementation.
+ * Represents something that can hold permissions.
  */
-@Internal
-public class SpongePluginManager extends PluginManager {
+public interface PermissionHolder {
 
-    @Override
-    public @NotNull Set<PlatformPlugin> getPlugins() {
-        return Sponge.pluginManager().plugins().stream().map(SpongePlugin::new).collect(Collectors.toSet());
-    }
-
-    @Override
-    public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
-        return Sponge.pluginManager().plugin(name.toLowerCase()).map(SpongePlugin::new);
-    }
-
-    @Override
-    public boolean isPluginEnabled(@NotNull String name) {
-        return Sponge.pluginManager().plugin(name.toLowerCase()).isPresent();
-    }
+    /**
+     * Checks whether this permission holder has the given permission.
+     *
+     * @param permission Permission.
+     *
+     * @return {@code true} if this permission holder has the given permission, otherwise
+     *     {@code false}.
+     */
+    boolean hasPermission(@NotNull String permission);
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/users/ProxyUser.java
+++ b/api/src/main/java/dev/hypera/chameleon/users/ProxyUser.java
@@ -21,58 +21,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.context;
+package dev.hypera.chameleon.users;
 
-import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.users.ChatUser;
-import org.jetbrains.annotations.ApiStatus.Internal;
+import dev.hypera.chameleon.platform.proxy.ProxyPlatform;
+import dev.hypera.chameleon.platform.proxy.Server;
+import java.util.Optional;
+import java.util.function.BiConsumer;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * {@link Context} implementation.
+ * Represents an in-game {@link User} on a {@link ProxyPlatform}.
  */
-public final class ContextImpl implements Context {
-
-    private final @NotNull ChatUser sender;
-    private final @NotNull Chameleon chameleon;
-    private final @NotNull String[] args;
+public interface ProxyUser extends User {
 
     /**
-     * {@link ContextImpl} constructor.
+     * Get the "sub-server" this user is currently connected to.
      *
-     * @param sender Command sender.
-     * @param chameleon {@link Chameleon} instance.
-     * @param args Command arguments.
+     * @return an {@code Optional} containing the {@link Server} the user is currently connected to,
+     *     or an empty optional if the user is not connected to a server.
      */
-    @Internal
-    public ContextImpl(@NotNull ChatUser sender, @NotNull Chameleon chameleon, @NotNull String[] args) {
-        this.sender = sender;
-        this.chameleon = chameleon;
-        this.args = args;
-    }
+    @NotNull Optional<Server> getServer();
 
     /**
-     * {@inheritDoc}
+     * Attempt to switch this user to the given {@link Server}.
+     *
+     * @param server {@link Server} to switch this user to.
      */
-    @Override
-    public @NotNull ChatUser getSender() {
-        return this.sender;
-    }
+    void connect(@NotNull Server server);
 
     /**
-     * {@inheritDoc}
+     * Attempt to switch this user to the given {@link Server} and then run the given callback.
+     *
+     * @param server   {@link Server} to switch this user to.
+     * @param callback Callback to run afterwards.
      */
-    @Override
-    public @NotNull Chameleon getChameleon() {
-        return this.chameleon;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull String[] getArgs() {
-        return this.args;
-    }
+    void connect(@NotNull Server server, @NotNull BiConsumer<Boolean, Throwable> callback);
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/users/ServerUser.java
+++ b/api/src/main/java/dev/hypera/chameleon/users/ServerUser.java
@@ -21,30 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.users.platforms;
+package dev.hypera.chameleon.users;
 
-import dev.hypera.chameleon.annotations.PlatformSpecific;
-import dev.hypera.chameleon.platform.Platform;
 import dev.hypera.chameleon.platform.server.GameMode;
 import dev.hypera.chameleon.platform.server.ServerPlatform;
-import dev.hypera.chameleon.users.User;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * In-game {@link User} on a {@link ServerPlatform}.
+ * Represents an in-game {@link User} on a {@link ServerPlatform}.
  */
-@PlatformSpecific(Platform.Type.SERVER)
 public interface ServerUser extends User {
 
     /**
-     * Get the current {@link GameMode} of this user.
+     * Get the current game mode of this user.
      *
-     * @return current {@link GameMode}.
+     * @return game mode.
      */
     @NotNull GameMode getGameMode();
 
     /**
-     * Set the {@link GameMode} of this user.
+     * Change the game mode of this user.
      *
      * @param gameMode New {@link GameMode}.
      */

--- a/api/src/main/java/dev/hypera/chameleon/users/User.java
+++ b/api/src/main/java/dev/hypera/chameleon/users/User.java
@@ -30,30 +30,31 @@ import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.NotNull;
 
 /**
- * An in-game player.
+ * Represents an in-game player, e.g. a person connected with the Minecraft client.
  */
 public interface User extends ChatUser {
 
     /**
-     * Get this user's unique identifier.
+     * Get the unique identifier of this user.
      *
      * @return unique identifier.
      */
-    @NotNull UUID getUniqueId();
+    @NotNull UUID getId();
 
     /**
-     * Get this user's SocketAddress.
+     * Get the address of this user.
      *
-     * @return SocketAddress, if available, otherwise empty.
+     * @return an {@code Optional} containing the address of this user, if available, otherwise an
+     *     empty optional.
      */
     @NotNull Optional<SocketAddress> getAddress();
 
     /**
-     * Get this user's ping.
+     * Get the latency in milliseconds between this user and the platform.
      *
-     * @return ping.
+     * @return latency between this user and the platform.
      */
-    int getPing();
+    int getLatency();
 
     /**
      * Send a chat message as this user.

--- a/api/src/main/resources/META-INF/CHAMELEON.txt
+++ b/api/src/main/resources/META-INF/CHAMELEON.txt
@@ -1,5 +1,5 @@
 Chameleon Framework - https://github.com/ChameleonFramework/Chameleon
-Copyright (c) 2021-present The Chameleon Framework Authors.
+Copyright (c) 2021-2022 The Chameleon Framework Authors.
 
 This software includes the Chameleon Framework, which is provided under the MIT license:
 

--- a/api/src/test/java/dev/hypera/chameleon/platform/PlatformTargetTests.java
+++ b/api/src/test/java/dev/hypera/chameleon/platform/PlatformTargetTests.java
@@ -1,0 +1,106 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2022 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import dev.hypera.chameleon.platform.objects.TestProxyPlatform;
+import dev.hypera.chameleon.platform.objects.TestServerPlatform;
+import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class PlatformTargetTests {
+
+    private static final @NotNull Platform PROXY_PLATFORM = new TestProxyPlatform();
+    private static final @NotNull Platform SERVER_PLATFORM = new TestServerPlatform();
+
+    @Test
+    void matchesAll() {
+        assertTrue(PlatformTarget.all().matches(PROXY_PLATFORM));
+        assertTrue(PlatformTarget.all().matches(SERVER_PLATFORM));
+    }
+
+    @Test
+    void matchesNone() {
+        assertFalse(PlatformTarget.none().matches(PROXY_PLATFORM));
+        assertFalse(PlatformTarget.none().matches(SERVER_PLATFORM));
+    }
+
+    @Test
+    void matchesProxy() {
+        assertTrue(PlatformTarget.proxy().matches(PROXY_PLATFORM));
+        assertFalse(PlatformTarget.proxy().matches(SERVER_PLATFORM));
+    }
+
+    @Test
+    void matchesServer() {
+        assertFalse(PlatformTarget.server().matches(PROXY_PLATFORM));
+        assertTrue(PlatformTarget.server().matches(SERVER_PLATFORM));
+    }
+
+    @ParameterizedTest
+    @MethodSource("getIdParams")
+    void matchesId(@NotNull String id, boolean proxy, boolean server) {
+        assertEquals(proxy, PlatformTarget.id(id).matches(PROXY_PLATFORM));
+        assertEquals(proxy, Platform.target(id).matches(PROXY_PLATFORM));
+        assertEquals(server, PlatformTarget.id(id).matches(SERVER_PLATFORM));
+        assertEquals(server, Platform.target(id).matches(SERVER_PLATFORM));
+    }
+
+    @Test
+    void equality() {
+        // id string matches
+        assertEquals(Platform.target("test").getId(), "test");
+
+        // #equals matches
+        PlatformTarget target = PlatformTarget.id("abc");
+        assertEquals(target, target);
+        assertEquals(Platform.target("test"), PlatformTarget.id("test"));
+        assertEquals(PlatformTarget.id("test"), Platform.target("test"));
+        assertNotEquals(PlatformTarget.id("test"), PlatformTarget.id("test2"));
+        assertNotEquals(PlatformTarget.id("test"), null);
+        assertNotEquals(PlatformTarget.id("test2"), new Object());
+
+        // hashcode matches
+        assertEquals(Platform.target("test").hashCode(), PlatformTarget.id("test").hashCode());
+    }
+
+    private static @NotNull Stream<Arguments> getIdParams() {
+        return Stream.of(
+            arguments("TestProxy", true, false),
+            arguments("TestServer", false, true),
+            arguments("testserver", false, true),
+            arguments("Neither", false, false)
+        );
+    }
+
+}

--- a/api/src/test/java/dev/hypera/chameleon/platform/objects/TestProxyPlatform.java
+++ b/api/src/test/java/dev/hypera/chameleon/platform/objects/TestProxyPlatform.java
@@ -21,13 +21,40 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.commands.objects;
+package dev.hypera.chameleon.platform.objects;
 
-/**
- * Command platform.
- */
-public enum Platform {
+import dev.hypera.chameleon.platform.proxy.ProxyPlatform;
+import dev.hypera.chameleon.platform.proxy.Server;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.jetbrains.annotations.NotNull;
 
-    ALL, PROXY, SERVER
+public class TestProxyPlatform implements ProxyPlatform {
+
+    @Override
+    public @NotNull String getId() {
+        return "TestProxy";
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "TestProxy";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return "@version@";
+    }
+
+    @Override
+    public @NotNull Set<Server> getServers() {
+        return new HashSet<>();
+    }
+
+    @Override
+    public @NotNull Optional<Server> getServer(@NotNull String name) {
+        return Optional.empty();
+    }
 
 }

--- a/api/src/test/java/dev/hypera/chameleon/platform/objects/TestServerPlatform.java
+++ b/api/src/test/java/dev/hypera/chameleon/platform/objects/TestServerPlatform.java
@@ -21,27 +21,26 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.annotations;
+package dev.hypera.chameleon.platform.objects;
 
-import dev.hypera.chameleon.platform.Platform;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import dev.hypera.chameleon.platform.server.ServerPlatform;
 import org.jetbrains.annotations.NotNull;
 
-/**
- * Marks a method or class as only working on a particular {@link Platform.Type}.
- */
-@Target({ ElementType.TYPE, ElementType.METHOD })
-@Retention(RetentionPolicy.RUNTIME)
-public @interface PlatformSpecific {
+public class TestServerPlatform implements ServerPlatform {
 
-    /**
-     * Get {@link Platform.Type}.
-     *
-     * @return the {@link Platform.Type} this method or class works on.
-     */
-    @NotNull Platform.Type value();
+    @Override
+    public @NotNull String getId() {
+        return "TestServer";
+    }
+
+    @Override
+    public @NotNull String getName() {
+        return "TestServer";
+    }
+
+    @Override
+    public @NotNull String getVersion() {
+        return "@version@";
+    }
 
 }

--- a/build-logic/src/main/kotlin/chameleon.common.gradle.kts
+++ b/build-logic/src/main/kotlin/chameleon.common.gradle.kts
@@ -24,6 +24,7 @@
 plugins {
     id("chameleon.base")
     id("chameleon.publishing")
+    jacoco
 }
 
 /* Apply JUnit and setup */
@@ -36,6 +37,13 @@ dependencies {
     testImplementation(libs.findLibrary("test-junit-params").get())
 }
 
-tasks.test {
-    useJUnitPlatform()
+tasks {
+    test {
+        useJUnitPlatform()
+        finalizedBy(jacocoTestReport)
+    }
+
+    jacocoTestReport {
+        dependsOn(test)
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 }
 
 group = "dev.hypera"
-version = "0.10.0-SNAPSHOT"
+version = "0.11.0-SNAPSHOT"
 description = "Cross-platform Minecraft plugin framework"
 
 indraSonatype {

--- a/example/src/main/java/dev/hypera/example/commands/ExampleCommand.java
+++ b/example/src/main/java/dev/hypera/example/commands/ExampleCommand.java
@@ -23,13 +23,13 @@
  */
 package dev.hypera.example.commands;
 
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.annotations.CommandHandler;
-import dev.hypera.chameleon.commands.annotations.Permission;
-import dev.hypera.chameleon.commands.annotations.SubCommandHandler;
-import dev.hypera.chameleon.commands.context.Context;
-import dev.hypera.chameleon.commands.objects.Condition;
-import dev.hypera.chameleon.commands.objects.Platform;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.annotations.CommandHandler;
+import dev.hypera.chameleon.command.annotations.Permission;
+import dev.hypera.chameleon.command.annotations.SubCommandHandler;
+import dev.hypera.chameleon.command.context.Context;
+import dev.hypera.chameleon.command.objects.Condition;
+import dev.hypera.chameleon.platform.PlatformTarget;
 import dev.hypera.chameleon.users.User;
 import java.util.Collections;
 import java.util.List;
@@ -50,7 +50,7 @@ public class ExampleCommand extends Command {
     public ExampleCommand() {
         setPermissionErrorMessage(Component.text("No permission.", NamedTextColor.RED));
         setConditions(Condition.of(c -> c.getSender() instanceof User, Component.text("This command can only be used in-game.", NamedTextColor.RED)));
-        setPlatform(Platform.ALL);
+        setPlatform(PlatformTarget.all());
     }
 
     /**

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/commands/BukkitCommand.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/commands/BukkitCommand.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.bukkit.commands;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.bukkit.user.BukkitUsers;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/events/BukkitListener.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/events/BukkitListener.java
@@ -29,8 +29,8 @@ import dev.hypera.chameleon.events.common.UserDisconnectEvent;
 import dev.hypera.chameleon.events.server.ServerUserKickEvent;
 import dev.hypera.chameleon.platform.bukkit.BukkitChameleon;
 import dev.hypera.chameleon.platform.bukkit.user.BukkitUser;
+import dev.hypera.chameleon.users.ServerUser;
 import dev.hypera.chameleon.users.User;
-import dev.hypera.chameleon.users.platforms.ServerUser;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -83,7 +83,11 @@ public class BukkitListener implements Listener {
      */
     @EventHandler
     public void onAsyncPlayerChatEvent(@NotNull AsyncPlayerChatEvent event) {
-        UserChatEvent chameleonEvent = new UserChatEvent(wrap(event.getPlayer()), event.getMessage(), event.isCancelled());
+        UserChatEvent chameleonEvent = new UserChatEvent(
+            wrap(event.getPlayer()),
+            event.getMessage(),
+            event.isCancelled()
+        );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 
         if (!event.getMessage().equals(chameleonEvent.getMessage())) {
@@ -112,7 +116,11 @@ public class BukkitListener implements Listener {
      */
     @EventHandler
     public void onPlayerKickEvent(@NotNull PlayerKickEvent event) {
-        this.chameleon.getEventBus().dispatch(new ServerUserKickEvent(wrap(event.getPlayer()), LegacyComponentSerializer.legacySection().deserialize(event.getReason())));
+        this.chameleon.getEventBus()
+            .dispatch(new ServerUserKickEvent(
+                wrap(event.getPlayer()),
+                LegacyComponentSerializer.legacySection().deserialize(event.getReason())
+            ));
     }
 
 

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/managers/BukkitCommandManager.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/managers/BukkitCommandManager.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.bukkit.managers;
 
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.bukkit.BukkitChameleon;
 import dev.hypera.chameleon.platform.bukkit.commands.BukkitCommand;

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/managers/BukkitPluginManager.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/managers/BukkitPluginManager.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.bukkit.managers;
 
 import dev.hypera.chameleon.managers.PluginManager;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.platform.bukkit.platform.objects.BukkitPlugin;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.Set;
@@ -53,7 +53,9 @@ public final class BukkitPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Set<PlatformPlugin> getPlugins() {
-        return Arrays.stream(Bukkit.getPluginManager().getPlugins()).map(BukkitPlugin::new).collect(Collectors.toSet());
+        return Arrays.stream(Bukkit.getPluginManager().getPlugins())
+            .map(BukkitPlugin::new)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -61,7 +63,8 @@ public final class BukkitPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
-        return Optional.ofNullable(Bukkit.getPluginManager().getPlugin(name)).map(BukkitPlugin::new);
+        return Optional.ofNullable(Bukkit.getPluginManager().getPlugin(name))
+            .map(BukkitPlugin::new);
     }
 
     /**

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/BukkitPlatform.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/BukkitPlatform.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
  * Bukkit {@link ServerPlatform} implementation.
  */
 @Internal
-public final class BukkitPlatform extends ServerPlatform {
+public final class BukkitPlatform implements ServerPlatform {
 
     /**
      * {@link BukkitPlatform} constructor.
@@ -46,7 +46,7 @@ public final class BukkitPlatform extends ServerPlatform {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return "Bukkit";
     }
 
@@ -64,14 +64,6 @@ public final class BukkitPlatform extends ServerPlatform {
     @Override
     public @NotNull String getVersion() {
         return Bukkit.getVersion();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull Type getType() {
-        return Type.SERVER;
     }
 
 }

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/objects/BukkitPlugin.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/objects/BukkitPlugin.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.bukkit.platform.objects;
 
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.utils.ChameleonUtil;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/user/BukkitUser.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/user/BukkitUser.java
@@ -26,7 +26,7 @@ package dev.hypera.chameleon.platform.bukkit.user;
 import dev.hypera.chameleon.adventure.AbstractAudience;
 import dev.hypera.chameleon.platform.bukkit.BukkitChameleon;
 import dev.hypera.chameleon.platform.server.GameMode;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.UUID;
@@ -80,7 +80,7 @@ public class BukkitUser extends AbstractAudience implements ServerUser {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.getUniqueId();
     }
 
@@ -96,7 +96,7 @@ public class BukkitUser extends AbstractAudience implements ServerUser {
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.getPing();
     }
 

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/commands/BungeeCordCommand.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/commands/BungeeCordCommand.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.bungeecord.commands;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.bungeecord.users.BungeeCordUsers;
 import java.util.Arrays;
 import net.md_5.bungee.api.CommandSender;

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/events/BungeeCordListener.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/events/BungeeCordListener.java
@@ -31,8 +31,8 @@ import dev.hypera.chameleon.platform.bungeecord.BungeeCordChameleon;
 import dev.hypera.chameleon.platform.bungeecord.platform.objects.BungeeCordServer;
 import dev.hypera.chameleon.platform.bungeecord.users.BungeeCordUser;
 import dev.hypera.chameleon.platform.proxy.Server;
+import dev.hypera.chameleon.users.ProxyUser;
 import dev.hypera.chameleon.users.User;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
 import java.util.Optional;
 import net.md_5.bungee.api.config.ServerInfo;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
@@ -88,7 +88,11 @@ public class BungeeCordListener implements Listener {
      */
     @EventHandler
     public void onChatEvent(@NotNull ChatEvent event) {
-        UserChatEvent chameleonEvent = new UserChatEvent(wrap((ProxiedPlayer) event.getSender()), event.getMessage(), event.isCancelled());
+        UserChatEvent chameleonEvent = new UserChatEvent(
+            wrap((ProxiedPlayer) event.getSender()),
+            event.getMessage(),
+            event.isCancelled()
+        );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 
         if (!event.getMessage().equals(chameleonEvent.getMessage())) {
@@ -117,7 +121,11 @@ public class BungeeCordListener implements Listener {
      */
     @EventHandler
     public void onServerSwitchEvent(@NotNull ServerSwitchEvent event) {
-        this.chameleon.getEventBus().dispatch(new ProxyUserSwitchEvent(wrap(event.getPlayer()), Optional.ofNullable(event.getFrom()).map(this::wrap).orElse(null), wrap(event.getPlayer().getServer().getInfo())));
+        this.chameleon.getEventBus()
+            .dispatch(new ProxyUserSwitchEvent(wrap(event.getPlayer()),
+                Optional.ofNullable(event.getFrom()).map(this::wrap).orElse(null),
+                wrap(event.getPlayer().getServer().getInfo())
+            ));
     }
 
 

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/managers/BungeeCordCommandManager.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/managers/BungeeCordCommandManager.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.bungeecord.managers;
 
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.bungeecord.BungeeCordChameleon;
 import dev.hypera.chameleon.platform.bungeecord.commands.BungeeCordCommand;

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/managers/BungeeCordPluginManager.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/managers/BungeeCordPluginManager.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.bungeecord.managers;
 
 import dev.hypera.chameleon.managers.PluginManager;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.platform.bungeecord.platform.objects.BungeeCordPlugin;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +52,12 @@ public final class BungeeCordPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Set<PlatformPlugin> getPlugins() {
-        return ProxyServer.getInstance().getPluginManager().getPlugins().stream().map(BungeeCordPlugin::new).collect(Collectors.toSet());
+        return ProxyServer.getInstance()
+            .getPluginManager()
+            .getPlugins()
+            .stream()
+            .map(BungeeCordPlugin::new)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -60,7 +65,8 @@ public final class BungeeCordPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
-        return Optional.ofNullable(ProxyServer.getInstance().getPluginManager().getPlugin(name)).map(BungeeCordPlugin::new);
+        return Optional.ofNullable(ProxyServer.getInstance().getPluginManager().getPlugin(name))
+            .map(BungeeCordPlugin::new);
     }
 
     /**

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/BungeeCordPlatform.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/BungeeCordPlatform.java
@@ -38,7 +38,7 @@ import org.jetbrains.annotations.NotNull;
  * BungeeCord {@link ProxyPlatform} implementation.
  */
 @Internal
-public final class BungeeCordPlatform extends ProxyPlatform {
+public final class BungeeCordPlatform implements ProxyPlatform {
 
     private final @NotNull BungeeCordChameleon chameleon;
 
@@ -57,7 +57,7 @@ public final class BungeeCordPlatform extends ProxyPlatform {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return "BungeeCord";
     }
 
@@ -76,15 +76,6 @@ public final class BungeeCordPlatform extends ProxyPlatform {
     public @NotNull String getVersion() {
         return ProxyServer.getInstance().getVersion();
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull Type getType() {
-        return Type.PROXY;
-    }
-
 
     /**
      * {@inheritDoc}

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordPlugin.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordPlugin.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.bungeecord.platform.objects;
 
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.utils.ChameleonUtil;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordServer.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordServer.java
@@ -26,7 +26,7 @@ package dev.hypera.chameleon.platform.bungeecord.platform.objects;
 import dev.hypera.chameleon.Chameleon;
 import dev.hypera.chameleon.platform.bungeecord.users.BungeeCordUser;
 import dev.hypera.chameleon.platform.proxy.Server;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.net.SocketAddress;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/users/BungeeCordUser.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/users/BungeeCordUser.java
@@ -27,7 +27,7 @@ import dev.hypera.chameleon.Chameleon;
 import dev.hypera.chameleon.adventure.AbstractAudience;
 import dev.hypera.chameleon.platform.bungeecord.platform.objects.BungeeCordServer;
 import dev.hypera.chameleon.platform.proxy.Server;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.UUID;
@@ -82,7 +82,7 @@ public class BungeeCordUser extends AbstractAudience implements ProxyUser {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.getUniqueId();
     }
 
@@ -98,7 +98,7 @@ public class BungeeCordUser extends AbstractAudience implements ProxyUser {
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.getPing();
     }
 

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/command/MinestomCommand.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/command/MinestomCommand.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.minestom.command;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.minestom.users.MinestomUsers;
 import java.util.Arrays;
 import org.jetbrains.annotations.ApiStatus.Internal;

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/events/MinestomListener.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/events/MinestomListener.java
@@ -30,7 +30,7 @@ import dev.hypera.chameleon.events.common.UserConnectEvent;
 import dev.hypera.chameleon.events.common.UserDisconnectEvent;
 import dev.hypera.chameleon.events.server.ServerUserKickEvent;
 import dev.hypera.chameleon.platform.minestom.users.MinestomUsers;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.EventListener;

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/managers/MinestomCommandManager.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/managers/MinestomCommandManager.java
@@ -24,7 +24,7 @@
 package dev.hypera.chameleon.platform.minestom.managers;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.minestom.command.MinestomCommand;
 import net.minestom.server.MinecraftServer;

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/managers/MinestomPluginManager.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/managers/MinestomPluginManager.java
@@ -24,8 +24,8 @@
 package dev.hypera.chameleon.platform.minestom.managers;
 
 import dev.hypera.chameleon.managers.PluginManager;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.platform.minestom.platform.objects.MinestomPlugin;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +52,11 @@ public final class MinestomPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Set<PlatformPlugin> getPlugins() {
-        return MinecraftServer.getExtensionManager().getExtensions().stream().map(MinestomPlugin::new).collect(Collectors.toSet());
+        return MinecraftServer.getExtensionManager()
+            .getExtensions()
+            .stream()
+            .map(MinestomPlugin::new)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -60,7 +64,8 @@ public final class MinestomPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
-        return Optional.ofNullable(MinecraftServer.getExtensionManager().getExtension(name)).map(MinestomPlugin::new);
+        return Optional.ofNullable(MinecraftServer.getExtensionManager().getExtension(name))
+            .map(MinestomPlugin::new);
     }
 
     /**

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/platform/MinestomPlatform.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/platform/MinestomPlatform.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.NotNull;
  * Minestom {@link ServerPlatform} implementation.
  */
 @Internal
-public final class MinestomPlatform extends ServerPlatform {
+public final class MinestomPlatform implements ServerPlatform {
 
     /**
      * {@link MinestomPlatform} constructor.
@@ -46,7 +46,7 @@ public final class MinestomPlatform extends ServerPlatform {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return "Minestom";
     }
 
@@ -64,14 +64,6 @@ public final class MinestomPlatform extends ServerPlatform {
     @Override
     public @NotNull String getVersion() {
         return MinecraftServer.VERSION_NAME;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull Type getType() {
-        return Type.SERVER;
     }
 
 }

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/platform/objects/MinestomPlugin.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/platform/objects/MinestomPlugin.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.minestom.platform.objects;
 
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;

--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/users/MinestomUser.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/users/MinestomUser.java
@@ -26,7 +26,7 @@ package dev.hypera.chameleon.platform.minestom.users;
 import dev.hypera.chameleon.adventure.AbstractReflectedAudience;
 import dev.hypera.chameleon.adventure.conversion.AdventureConverter;
 import dev.hypera.chameleon.platform.server.GameMode;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
@@ -88,7 +88,7 @@ public class MinestomUser extends AbstractReflectedAudience implements ServerUse
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.getUuid();
     }
 
@@ -104,7 +104,7 @@ public class MinestomUser extends AbstractReflectedAudience implements ServerUse
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.getLatency();
     }
 

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/commands/NukkitCommand.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/commands/NukkitCommand.java
@@ -25,8 +25,8 @@ package dev.hypera.chameleon.platform.nukkit.commands;
 
 import cn.nukkit.command.CommandSender;
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.nukkit.users.NukkitUsers;
 import java.util.Arrays;
 import org.jetbrains.annotations.ApiStatus.Internal;

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/listeners/NukkitListener.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/listeners/NukkitListener.java
@@ -36,7 +36,7 @@ import dev.hypera.chameleon.events.common.UserDisconnectEvent;
 import dev.hypera.chameleon.events.server.ServerUserKickEvent;
 import dev.hypera.chameleon.platform.nukkit.NukkitChameleon;
 import dev.hypera.chameleon.platform.nukkit.users.NukkitUser;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/managers/NukkitCommandManager.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/managers/NukkitCommandManager.java
@@ -24,7 +24,7 @@
 package dev.hypera.chameleon.platform.nukkit.managers;
 
 import cn.nukkit.Server;
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.nukkit.NukkitChameleon;
 import dev.hypera.chameleon.platform.nukkit.commands.NukkitCommand;

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/managers/NukkitPluginManager.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/managers/NukkitPluginManager.java
@@ -26,8 +26,8 @@ package dev.hypera.chameleon.platform.nukkit.managers;
 import cn.nukkit.Server;
 import cn.nukkit.plugin.Plugin;
 import dev.hypera.chameleon.managers.PluginManager;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.platform.nukkit.platform.plugin.NukkitPlugin;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,7 +52,13 @@ public class NukkitPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Set<PlatformPlugin> getPlugins() {
-        return Server.getInstance().getPluginManager().getPlugins().values().stream().map(NukkitPlugin::new).collect(Collectors.toSet());
+        return Server.getInstance()
+            .getPluginManager()
+            .getPlugins()
+            .values()
+            .stream()
+            .map(NukkitPlugin::new)
+            .collect(Collectors.toSet());
     }
 
     /**
@@ -60,7 +66,8 @@ public class NukkitPluginManager extends PluginManager {
      */
     @Override
     public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
-        return Optional.ofNullable(Server.getInstance().getPluginManager().getPlugin(name)).map(NukkitPlugin::new);
+        return Optional.ofNullable(Server.getInstance().getPluginManager().getPlugin(name))
+            .map(NukkitPlugin::new);
     }
 
     /**
@@ -68,7 +75,9 @@ public class NukkitPluginManager extends PluginManager {
      */
     @Override
     public boolean isPluginEnabled(@NotNull String name) {
-        return Optional.ofNullable(Server.getInstance().getPluginManager().getPlugin(name)).map(Plugin::isEnabled).orElse(false);
+        return Optional.ofNullable(Server.getInstance().getPluginManager().getPlugin(name))
+            .map(Plugin::isEnabled)
+            .orElse(false);
     }
 
 }

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/NukkitPlatform.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/NukkitPlatform.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.NotNull;
  * Nukkit {@link ServerPlatform} implementation.
  */
 @Internal
-public class NukkitPlatform extends ServerPlatform {
+public class NukkitPlatform implements ServerPlatform {
 
     /**
      * {@link NukkitPlatform} constructor.
@@ -47,7 +47,7 @@ public class NukkitPlatform extends ServerPlatform {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return "Nukkit";
     }
 
@@ -65,14 +65,6 @@ public class NukkitPlatform extends ServerPlatform {
     @Override
     public @NotNull String getVersion() {
         return Nukkit.VERSION + " (" + Server.getInstance().getVersion() + ")";
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull Type getType() {
-        return Type.SERVER;
     }
 
 }

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/plugin/NukkitPlugin.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/plugin/NukkitPlugin.java
@@ -25,7 +25,7 @@ package dev.hypera.chameleon.platform.nukkit.platform.plugin;
 
 import cn.nukkit.Server;
 import cn.nukkit.plugin.Plugin;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.utils.ChameleonUtil;
 import java.nio.file.Path;
 import java.util.Collections;

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/users/NukkitUser.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/users/NukkitUser.java
@@ -26,7 +26,7 @@ package dev.hypera.chameleon.platform.nukkit.users;
 import cn.nukkit.Player;
 import dev.hypera.chameleon.platform.nukkit.adventure.AbstractNukkitAudience;
 import dev.hypera.chameleon.platform.server.GameMode;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import java.net.SocketAddress;
 import java.util.Optional;
 import java.util.UUID;
@@ -73,7 +73,7 @@ public class NukkitUser extends AbstractNukkitAudience implements ServerUser {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.getUniqueId();
     }
 
@@ -89,7 +89,7 @@ public class NukkitUser extends AbstractNukkitAudience implements ServerUser {
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.getPing();
     }
 

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/commands/SpongeCommand.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/commands/SpongeCommand.java
@@ -24,9 +24,9 @@
 package dev.hypera.chameleon.platform.sponge.commands;
 
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.Context;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.Context;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.sponge.users.SpongeUsers;
 import java.util.Arrays;
 import java.util.List;

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/events/SpongeListener.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/events/SpongeListener.java
@@ -30,7 +30,7 @@ import dev.hypera.chameleon.events.common.UserConnectEvent;
 import dev.hypera.chameleon.events.common.UserDisconnectEvent;
 import dev.hypera.chameleon.events.server.ServerUserKickEvent;
 import dev.hypera.chameleon.platform.sponge.users.SpongeUsers;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/managers/SpongeCommandManager.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/managers/SpongeCommandManager.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.sponge.managers;
 
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.sponge.SpongeChameleon;
 import dev.hypera.chameleon.platform.sponge.commands.SpongeCommand;

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/SpongePlatform.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/SpongePlatform.java
@@ -33,26 +33,30 @@ import org.spongepowered.api.Sponge;
  * Sponge {@link ServerPlatform} implementation.
  */
 @Internal
-public final class SpongePlatform extends ServerPlatform {
+public final class SpongePlatform implements ServerPlatform {
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return Sponge.game().platform().container(Component.API).metadata().name().orElse("Sponge");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull String getName() {
         return Sponge.game().platform().container(Component.IMPLEMENTATION).metadata().name().orElse("Sponge");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull String getVersion() {
         return Sponge.game().platform().container(Component.IMPLEMENTATION).metadata().version().toString() + " (" + Sponge.game().platform().container(Component.API).metadata().version() + ")";
-    }
-
-    @Override
-    public @NotNull Type getType() {
-        return Type.SERVER;
     }
 
 }

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/plugin/SpongePlugin.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/plugin/SpongePlugin.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.sponge.platform.plugin;
 
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/users/SpongeUser.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/users/SpongeUser.java
@@ -26,7 +26,7 @@ package dev.hypera.chameleon.platform.sponge.users;
 import dev.hypera.chameleon.adventure.AbstractReflectedAudience;
 import dev.hypera.chameleon.adventure.conversion.AdventureConverter;
 import dev.hypera.chameleon.platform.server.GameMode;
-import dev.hypera.chameleon.users.platforms.ServerUser;
+import dev.hypera.chameleon.users.ServerUser;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
@@ -93,7 +93,7 @@ public class SpongeUser extends AbstractReflectedAudience implements ServerUser 
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.uniqueId();
     }
 
@@ -109,7 +109,7 @@ public class SpongeUser extends AbstractReflectedAudience implements ServerUser 
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.connection().latency();
     }
 

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/adventure/VelocityAudienceProvider.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/adventure/VelocityAudienceProvider.java
@@ -30,7 +30,7 @@ import dev.hypera.chameleon.platform.velocity.user.VelocityConsoleUser;
 import dev.hypera.chameleon.platform.velocity.user.VelocityUser;
 import dev.hypera.chameleon.platform.velocity.user.VelocityUsers;
 import dev.hypera.chameleon.users.ChatUser;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/commands/VelocityCommand.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/commands/VelocityCommand.java
@@ -25,8 +25,8 @@ package dev.hypera.chameleon.platform.velocity.commands;
 
 import com.velocitypowered.api.command.SimpleCommand;
 import dev.hypera.chameleon.Chameleon;
-import dev.hypera.chameleon.commands.Command;
-import dev.hypera.chameleon.commands.context.ContextImpl;
+import dev.hypera.chameleon.command.Command;
+import dev.hypera.chameleon.command.context.ContextImpl;
 import dev.hypera.chameleon.platform.velocity.user.VelocityUsers;
 import java.util.Arrays;
 import java.util.List;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/events/VelocityListener.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/events/VelocityListener.java
@@ -39,8 +39,8 @@ import dev.hypera.chameleon.platform.proxy.Server;
 import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.platform.objects.VelocityServer;
 import dev.hypera.chameleon.platform.velocity.user.VelocityUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import dev.hypera.chameleon.users.User;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
@@ -85,7 +85,10 @@ public class VelocityListener {
      */
     @Subscribe
     public void onChatEvent(@NotNull PlayerChatEvent event) {
-        UserChatEvent chameleonEvent = new UserChatEvent(wrap(event.getPlayer()), event.getMessage(), !event.getResult().isAllowed());
+        UserChatEvent chameleonEvent = new UserChatEvent(wrap(event.getPlayer()),
+            event.getMessage(),
+            !event.getResult().isAllowed()
+        );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 
         if (!event.getMessage().equals(chameleonEvent.getMessage())) {
@@ -118,14 +121,23 @@ public class VelocityListener {
      */
     @Subscribe
     public void onServerSwitchEvent(@NotNull ServerConnectedEvent event) {
-        this.chameleon.getEventBus().dispatch(new ProxyUserSwitchEvent(wrap(event.getPlayer()), event.getPreviousServer().map(this::wrap).orElse(null), wrap(event.getServer())));
+        this.chameleon.getEventBus().dispatch(new ProxyUserSwitchEvent(wrap(event.getPlayer()),
+            event.getPreviousServer().map(this::wrap).orElse(null),
+            wrap(event.getServer())
+        ));
     }
 
     private boolean catchChatModification(@NotNull Player player, boolean cancel) {
         if (player.getProtocolVersion().getProtocol() >= 760) {
-            this.chameleon.getInternalLogger().error("Failed to %s a chat message for a player using 1.19.1 or above, doing so may result in Velocity throwing an exception and the sender being disconnected.", cancel ? "cancel" : "modify");
-            this.chameleon.getInternalLogger().error("This IS NOT a bug, but rather an intentional change in Velocity caused by changes in Minecraft 1.19.1.");
-            this.chameleon.getInternalLogger().error("See https://github.com/PaperMC/Velocity/issues/804 for more information.");
+            this.chameleon.getInternalLogger().error(
+                "Failed to %s a chat message for a player using 1.19.1 or above, doing so may result in Velocity throwing an exception and the sender being disconnected.",
+                cancel ? "cancel" : "modify"
+            );
+            this.chameleon.getInternalLogger()
+                .error(
+                    "This IS NOT a bug, but rather an intentional change in Velocity caused by changes in Minecraft 1.19.1.");
+            this.chameleon.getInternalLogger()
+                .error("See https://github.com/PaperMC/Velocity/issues/804 for more information.");
             return false;
         } else {
             return true;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/managers/VelocityCommandManager.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/managers/VelocityCommandManager.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.platform.velocity.managers;
 
-import dev.hypera.chameleon.commands.Command;
+import dev.hypera.chameleon.command.Command;
 import dev.hypera.chameleon.managers.CommandManager;
 import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.commands.VelocityCommand;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/managers/VelocityPluginManager.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/managers/VelocityPluginManager.java
@@ -24,7 +24,7 @@
 package dev.hypera.chameleon.platform.velocity.managers;
 
 import dev.hypera.chameleon.managers.PluginManager;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.platform.objects.VelocityPlugin;
 import java.util.Optional;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/VelocityPlatform.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/VelocityPlatform.java
@@ -37,7 +37,7 @@ import org.jetbrains.annotations.NotNull;
  * Velocity {@link ProxyPlatform} implementation.
  */
 @Internal
-public final class VelocityPlatform extends ProxyPlatform {
+public final class VelocityPlatform implements ProxyPlatform {
 
     private final @NotNull VelocityChameleon chameleon;
 
@@ -56,7 +56,7 @@ public final class VelocityPlatform extends ProxyPlatform {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull String getAPIName() {
+    public @NotNull String getId() {
         return "Velocity";
     }
 
@@ -75,15 +75,6 @@ public final class VelocityPlatform extends ProxyPlatform {
     public @NotNull String getVersion() {
         return this.chameleon.getPlatformPlugin().getServer().getVersion().getVersion();
     }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public @NotNull Type getType() {
-        return Type.PROXY;
-    }
-
 
     /**
      * {@inheritDoc}

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityPlugin.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityPlugin.java
@@ -25,7 +25,7 @@ package dev.hypera.chameleon.platform.velocity.platform.objects;
 
 import com.velocitypowered.api.plugin.PluginContainer;
 import com.velocitypowered.api.plugin.meta.PluginDependency;
-import dev.hypera.chameleon.platform.objects.PlatformPlugin;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityServer.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityServer.java
@@ -28,7 +28,7 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.hypera.chameleon.platform.proxy.Server;
 import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.user.VelocityUser;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.net.SocketAddress;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/user/VelocityUser.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/user/VelocityUser.java
@@ -30,7 +30,7 @@ import dev.hypera.chameleon.adventure.conversion.AdventureConverter;
 import dev.hypera.chameleon.platform.proxy.Server;
 import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.platform.objects.VelocityServer;
-import dev.hypera.chameleon.users.platforms.ProxyUser;
+import dev.hypera.chameleon.users.ProxyUser;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.SocketAddress;
@@ -95,7 +95,7 @@ public class VelocityUser extends AbstractReflectedAudience implements ProxyUser
      * {@inheritDoc}
      */
     @Override
-    public @NotNull UUID getUniqueId() {
+    public @NotNull UUID getId() {
         return this.player.getUniqueId();
     }
 
@@ -111,7 +111,7 @@ public class VelocityUser extends AbstractReflectedAudience implements ProxyUser
      * {@inheritDoc}
      */
     @Override
-    public int getPing() {
+    public int getLatency() {
         return this.player.getPing() > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) this.player.getPing();
     }
 


### PR DESCRIPTION
BREAKING CHANGES: Removal of Platform.Type enums, repackage some classes, rename several methods

**Summary**
Replace platform type enums with `PlatformTarget`, repackage some classes, overall improvements, and more.

**Changes**
 - Replace platform type enums with `PlatformTarget`.
 - Rename `commands` package to `command`.
 - Improve javadoc in `users` and `platform` packages.
 - Remove cast methods like `proxy()`, `server()`, etc.
 - **Rename `User#getUniqueId()` to `User#getId()`.**
 - **Rename `User#getPing()` to `User#getLatency()`.**
 - Improve test coverage for the event bus.
 - Add Jacoco test coverage reports.
 - Bump version to `0.11.0-SNAPSHOT`.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [x] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
**This pull request contains *majorly* breaking changes.**
