### PR TITLE
chore: add MacStadium to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ This project was made possible by the [amazing people who have contributed](http
 ### Supporters
 People and companies who have donated or provided us with something that aids us in continuing this project.  
 [![JetBrains](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_square.svg)](https://jb.gg/OpenSourceSupport)
+[![MacStadium](https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png)](https://www.macstadium.com/)
 
 ### Plugins
 Plugins or resources that have been created using Chameleon.  

--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ This project was made possible by the [amazing people who have contributed](http
 
 ### Supporters
 People and companies who have donated or provided us with something that aids us in continuing this project.  
-[![JetBrains](https://resources.jetbrains.com/storage/products/company/brand/logos/jb_square.svg)](https://jb.gg/OpenSourceSupport)
-[![MacStadium](https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png)](https://www.macstadium.com/)
+<a href="https://jb.gg/OpenSourceSupport"><img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jb_square.svg" alt="JetBrains" height="82"/></a>
+<a href="https://www.macstadium.com/"><img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium" height="82"/></a>
 
 ### Plugins
 Plugins or resources that have been created using Chameleon.  


### PR DESCRIPTION
**Summary**
Add the MacStadium Open Source Developer logo to the README file.  
[MacStadium](https://www.macstadium.com/opensource) offers free Mac Minis for Open Source developers to build projects on MacOS. This would be helpful for Chameleon as we can run tests on the `main` branch using these powerful Mac Minis.  
The application for Chameleon was accepted, the account completion is currently pending.

**Changes**
 - Add the MacStadium Open Source Developer logo to the Supporters section of the README file.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->