### PR TITLE
fix(bukkit): prevent early usage of Adventure

### DIFF
--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
@@ -44,7 +44,6 @@ import dev.hypera.chameleon.scheduler.Scheduler;
 import dev.hypera.chameleon.util.Preconditions;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.Objects;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.ApiStatus.Internal;
@@ -88,16 +87,8 @@ public final class BukkitChameleon extends Chameleon {
      * {@inheritDoc}
      */
     @Override
-    public void onLoad() {
-        this.audienceProvider = new BukkitAudienceProvider(this, this.plugin);
-        super.onLoad();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void onEnable() {
+        this.audienceProvider = new BukkitAudienceProvider(this, this.plugin);
         Bukkit.getPluginManager().registerEvents(new BukkitListener(this), this.plugin);
         super.onEnable();
     }
@@ -119,7 +110,7 @@ public final class BukkitChameleon extends Chameleon {
         Preconditions.checkState(
             this.audienceProvider != null, "Chameleon has not been loaded"
         );
-        return Objects.requireNonNull(this.audienceProvider);
+        return this.audienceProvider;
     }
 
     /**

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/user/BukkitUserManager.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/user/BukkitUserManager.java
@@ -38,6 +38,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Bukkit user manager implementation.
@@ -46,7 +47,8 @@ import org.jetbrains.annotations.NotNull;
 public final class BukkitUserManager implements UserManager {
 
     private final @NotNull BukkitChameleon chameleon;
-    private final @NotNull BukkitConsoleUser consoleUser;
+
+    private @Nullable BukkitConsoleUser consoleUser;
 
     /**
      * Bukkit user manager constructor.
@@ -56,7 +58,6 @@ public final class BukkitUserManager implements UserManager {
     @Internal
     public BukkitUserManager(@NotNull BukkitChameleon chameleon) {
         this.chameleon = chameleon;
-        this.consoleUser = new BukkitConsoleUser(this.chameleon);
     }
 
     /**
@@ -64,6 +65,7 @@ public final class BukkitUserManager implements UserManager {
      */
     @Override
     public @NotNull ConsoleUser getConsole() {
+        if (this.consoleUser == null) this.consoleUser = new BukkitConsoleUser(this.chameleon);
         return this.consoleUser;
     }
 


### PR DESCRIPTION
**Summary**
Allows Chameleon plugins to load on Bukkit platforms.

**Changes**
* Prevent early usage of Adventure.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->