### PR TITLE
fix(bungeecord): make console sender a lazy initialiser

### DIFF
--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/user/BungeeCordUserManager.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/user/BungeeCordUserManager.java
@@ -38,6 +38,7 @@ import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.connection.ProxiedPlayer;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * BungeeCord user manager implementation.
@@ -46,7 +47,8 @@ import org.jetbrains.annotations.NotNull;
 public final class BungeeCordUserManager implements UserManager {
 
     private final @NotNull BungeeCordChameleon chameleon;
-    private final @NotNull BungeeCordConsoleUser consoleUser;
+
+    private @Nullable BungeeCordConsoleUser consoleUser;
 
     /**
      * BungeeCord user manager constructor.
@@ -56,7 +58,6 @@ public final class BungeeCordUserManager implements UserManager {
     @Internal
     public BungeeCordUserManager(@NotNull BungeeCordChameleon chameleon) {
         this.chameleon = chameleon;
-        this.consoleUser = new BungeeCordConsoleUser(chameleon);
     }
 
     /**
@@ -64,6 +65,7 @@ public final class BungeeCordUserManager implements UserManager {
      */
     @Override
     public @NotNull ConsoleUser getConsole() {
+        if (this.consoleUser == null) this.consoleUser = new BungeeCordConsoleUser(this.chameleon);
         return this.consoleUser;
     }
 


### PR DESCRIPTION
**Summary**
Fixes #202 

**Changes**
Make console sender a lazy initialiser.

**Checklist**
- [X] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [X] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [X] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->