### PR TITLE
feat: add Folia Support

### DIFF
--- a/annotations/build.gradle.kts
+++ b/annotations/build.gradle.kts
@@ -38,9 +38,3 @@ dependencies {
 
     implementation(libs.gson)
 }
-
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-}

--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/ChameleonAnnotationProcessor.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/ChameleonAnnotationProcessor.java
@@ -28,6 +28,7 @@ import dev.hypera.chameleon.annotations.exception.ChameleonAnnotationException;
 import dev.hypera.chameleon.annotations.processing.generation.Generator;
 import dev.hypera.chameleon.annotations.processing.generation.bukkit.BukkitGenerator;
 import dev.hypera.chameleon.annotations.processing.generation.bungeecord.BungeeCordGenerator;
+import dev.hypera.chameleon.annotations.processing.generation.folia.FoliaGenerator;
 import dev.hypera.chameleon.annotations.processing.generation.minestom.MinestomGenerator;
 import dev.hypera.chameleon.annotations.processing.generation.nukkit.NukkitGenerator;
 import dev.hypera.chameleon.annotations.processing.generation.sponge.SpongeGenerator;
@@ -48,7 +49,7 @@ import javax.lang.model.element.TypeElement;
  * Chameleon Annotation Processor.
  */
 @SupportedAnnotationTypes("dev.hypera.chameleon.annotations.Plugin")
-@SupportedSourceVersion(SourceVersion.RELEASE_8)
+@SupportedSourceVersion(SourceVersion.RELEASE_11)
 public class ChameleonAnnotationProcessor extends AbstractProcessor {
 
     /**
@@ -79,6 +80,9 @@ public class ChameleonAnnotationProcessor extends AbstractProcessor {
                         break;
                     case Platform.BUNGEECORD:
                         generator = new BungeeCordGenerator();
+                        break;
+                    case Platform.FOLIA:
+                        generator = new FoliaGenerator();
                         break;
                     case Platform.MINESTOM:
                         generator = new MinestomGenerator();

--- a/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/folia/FoliaGenerator.java
+++ b/annotations/src/main/java/dev/hypera/chameleon/annotations/processing/generation/folia/FoliaGenerator.java
@@ -1,0 +1,132 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.annotations.processing.generation.folia;
+
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.JavaFile;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.TypeSpec;
+import dev.hypera.chameleon.annotations.Plugin;
+import dev.hypera.chameleon.annotations.exception.ChameleonAnnotationException;
+import dev.hypera.chameleon.annotations.processing.generation.Generator;
+import dev.hypera.chameleon.annotations.utils.MapBuilder;
+import dev.hypera.chameleon.exception.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.platform.Platform;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.StandardLocation;
+import org.jetbrains.annotations.NotNull;
+import org.yaml.snakeyaml.Yaml;
+
+/**
+ * Bukkit plugin main class and 'paper-plugin.yml' description file generator.
+ */
+public final class FoliaGenerator extends Generator {
+
+    private static final @NotNull String DESCRIPTION_FILE = "paper-plugin.yml";
+
+    /**
+     * Generate Bukkit plugin main class and 'plugin.yml' description file.
+     *
+     * @param data   {@link Plugin} data
+     * @param plugin Chameleon plugin main class
+     * @param env    Processing environment
+     *
+     * @throws ChameleonAnnotationException if something goes wrong while creating the files.
+     */
+    @Override
+    public void generate(@NotNull Plugin data, @NotNull TypeElement plugin, @NotNull ProcessingEnvironment env) throws ChameleonAnnotationException {
+        MethodSpec constructorSpec = MethodSpec.constructorBuilder()
+                .addModifiers(Modifier.PUBLIC)
+                .beginControlFlow("try")
+                .addStatement(createPluginData(data))
+                .addStatement("this.$N = $T.createFoliaBootstrap($T.class, this, $N).load()", CHAMELEON_VAR, clazz("dev.hypera.chameleon.platform.folia", "FoliaChameleon"), plugin, "pluginData")
+                .nextControlFlow("catch ($T ex)", ChameleonInstantiationException.class)
+                .addStatement("getLogger().log($T.SEVERE, \"An error occurred while loading Chameleon\", $N)", Level.class, "ex")
+                .addStatement("throw new $T($N)", clazz("dev.hypera.chameleon.exception", "ChameleonRuntimeException"), "ex")
+                .endControlFlow()
+                .build();
+
+        MethodSpec enableSpec = MethodSpec.methodBuilder("onEnable")
+            .addAnnotation(Override.class).addModifiers(Modifier.PUBLIC)
+            .addStatement("this.$N.onEnable()", CHAMELEON_VAR).build();
+
+        MethodSpec disableSpec = MethodSpec.methodBuilder("onDisable")
+            .addAnnotation(Override.class).addModifiers(Modifier.PUBLIC)
+            .addStatement("this.$N.onDisable()", CHAMELEON_VAR).build();
+
+        TypeSpec foliaMainClassSpec = TypeSpec.classBuilder(plugin.getSimpleName() + "Folia")
+            .addModifiers(Modifier.PUBLIC, Modifier.FINAL)
+            .superclass(clazz("org.bukkit.plugin.java", "JavaPlugin"))
+            .addField(FieldSpec.builder(clazz("dev.hypera.chameleon.platform.folia", "FoliaChameleon"), CHAMELEON_VAR, Modifier.PRIVATE).build())
+            .addMethod(constructorSpec)
+            .addMethod(enableSpec)
+            .addMethod(disableSpec)
+            .build();
+
+        String packageName = Objects.requireNonNull((PackageElement) plugin.getEnclosingElement()).getQualifiedName().toString();
+        if (packageName.endsWith("core") || packageName.endsWith("common")) {
+            packageName = packageName.substring(0, packageName.lastIndexOf("."));
+        }
+        packageName = packageName + ".platform.folia";
+
+        try {
+            JavaFile.builder(packageName, foliaMainClassSpec).indent(INDENT).build().writeTo(env.getFiler());
+            generateDescriptionFile(data, plugin, env, packageName);
+        } catch (IOException ex) {
+            throw new ChameleonAnnotationException("Failed to write main class or description file", ex);
+        }
+    }
+
+    private void generateDescriptionFile(@NotNull Plugin data, @NotNull TypeElement plugin, @NotNull ProcessingEnvironment env, @NotNull String packageName) throws IOException {
+        try (BufferedWriter writer = Files.newBufferedWriter(Paths.get(env.getFiler().createResource(StandardLocation.CLASS_OUTPUT, "", DESCRIPTION_FILE).toUri()))) {
+            new Yaml().dump(new MapBuilder<String, Object>().add("name", data.name().isEmpty() ? data.id() : data.name())
+                .add("main", packageName + "." + plugin.getSimpleName() + "Folia")
+                .add("version", data.version())
+                .add("api-version", "1.19")
+                .add("author", data.authors().length > 0 ? String.join(", ", data.authors()) : "Unknown")
+                .add("authors", data.authors())
+                .add("website", data.url())
+                .add("dependencies", Arrays.stream(data.dependencies())
+                        .filter(d -> (d.platforms().length == 0 || Arrays.asList(d.platforms()).contains(Platform.FOLIA)))
+                        .map(d -> new MapBuilder<String, Object>()
+                                .add("name", d.name())
+                                .add("required", !d.soft())
+                        ).collect(Collectors.toList()))
+                .add("description", data.description())
+                .add("folia-supported", "true"), writer);
+        }
+    }
+
+}

--- a/api/src/main/java/dev/hypera/chameleon/platform/Platform.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/Platform.java
@@ -34,6 +34,7 @@ public interface Platform {
 
     @NotNull String BUKKIT = "Bukkit";
     @NotNull String BUNGEECORD = "BungeeCord";
+    @NotNull String FOLIA = "Folia";
     @NotNull String MINESTOM = "Minestom";
     @NotNull String NUKKIT = "Nukkit";
     @NotNull String SPONGE = "Sponge";

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -42,6 +42,6 @@ dependencies {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }

--- a/build-logic/src/main/kotlin/chameleon.base.gradle.kts
+++ b/build-logic/src/main/kotlin/chameleon.base.gradle.kts
@@ -41,7 +41,7 @@ val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
 
 indra {
     javaVersions {
-        if (project.name.contains("minestom") || project.name.contains("sponge") || project.name.contains("example")) {
+        if (project.name.contains("folia") || project.name.contains("minestom") || project.name.contains("sponge") || project.name.contains("example")) {
             target(17)
             testWith(17)
         } else {

--- a/build-logic/src/main/kotlin/chameleon.base.gradle.kts
+++ b/build-logic/src/main/kotlin/chameleon.base.gradle.kts
@@ -38,10 +38,16 @@ plugins {
 }
 
 val libs = extensions.getByType<VersionCatalogsExtension>().named("libs")
+val requires17 = setOf(
+    "chameleon-example",
+    "chameleon-platform-folia",
+    "chameleon-platform-minestom",
+    "chameleon-platform-sponge",
+)
 
 indra {
     javaVersions {
-        if (project.name.contains("folia") || project.name.contains("minestom") || project.name.contains("sponge") || project.name.contains("example")) {
+        if (project.name in requires17) {
             target(17)
             testWith(17)
         } else {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
  */
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
         targetCompatibility = JavaVersion.VERSION_17
     }
 }
@@ -41,6 +41,7 @@ java {
 repositories {
     maven("https://oss.sonatype.org/content/repositories/snapshots/") // Required for BungeeCord support
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") // Required for Bukkit support
+    maven("https://papermc.io/repo/repository/maven-public/") // Required for Folia support
     // maven("https://jitpack.io/") // Required for Minestom support
     maven("https://repo.spongepowered.org/maven/") // Required for Minestom/Sponge support
     maven("https://repo.opencollab.dev/main/") // Required for Nukkit support
@@ -60,6 +61,7 @@ dependencies {
     implementation(project(":chameleon-api")) // dev.hypera:chameleon-api
     implementation(project(":chameleon-platform-bukkit")) // dev.hypera:chameleon-platform-bukkit
     implementation(project(":chameleon-platform-bungeecord")) // dev.hypera:chameleon-platform-bungeecord
+    implementation(project(":chameleon-platform-folia")) // dev.hypera:chameleon-platform-folia
     implementation(project(":chameleon-platform-nukkit")) // dev.hypera:chameleon-platform-nukkit
     implementation(project(":chameleon-platform-minestom")) // dev.hypera:chameleon-platform-minestom
     implementation(project(":chameleon-platform-velocity")) // dev.hypera:chameleon-platform-velocity
@@ -79,7 +81,7 @@ tasks {
         mergeServiceFiles()
 
         /* IMPORTANT: Relocate all dependencies to avoid conflicts */
-        relocate("dev.hypera.chameleon", "dev.hypera.chameleon.example.lib.chameleon")
+        //relocate("dev.hypera.chameleon", "dev.hypera.chameleon.example.lib.chameleon") // Cannot relocate because example is in this package.
         relocate("net.kyori", "dev.hypera.chameleon.example.lib.kyori")
         relocate("com.google.gson", "dev.hypera.chameleon.example.lib.gson")
     }

--- a/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
+++ b/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
@@ -35,6 +35,7 @@ import dev.hypera.chameleon.example.command.ExampleCommand;
 import dev.hypera.chameleon.example.event.ExampleCustomEvent;
 import dev.hypera.chameleon.logger.ChameleonLogger;
 import dev.hypera.chameleon.platform.Platform;
+import dev.hypera.chameleon.platform.PlatformPlugin;
 import dev.hypera.chameleon.scheduler.Schedule;
 import dev.hypera.chameleon.scheduler.Task;
 import java.time.Duration;
@@ -56,7 +57,7 @@ import org.jetbrains.annotations.NotNull;
         dependencies = {
             @Dependency(
                 name = "LuckPerms",
-                soft = true,
+                soft = false,
                 platforms = { Platform.BUKKIT, Platform.FOLIA }
             )
         },
@@ -130,6 +131,11 @@ public final class ChameleonExample extends ChameleonPlugin {
         chameleon.getScheduler().schedule(Task.builder(() ->
             this.logger.info("This task will run twice!")
         ).delay(Schedule.seconds(2)).repeat(Schedule.seconds(5)).cancelAfter(2).build());
+
+        /* Plugin Management */
+        for (PlatformPlugin plugin : chameleon.getPluginManager().getPlugins()) {
+            this.logger.info("Found plugin %s v%s", plugin.getName(), plugin.getVersion());
+        }
 
         this.logger.info(
             "Successfully started ChameleonExample plugin, took %s ms.",

--- a/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
+++ b/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
@@ -57,12 +57,13 @@ import org.jetbrains.annotations.NotNull;
             @Dependency(
                 name = "LuckPerms",
                 soft = true,
-                platforms = { Platform.BUKKIT }
+                platforms = { Platform.BUKKIT, Platform.FOLIA }
             )
         },
         platforms = {
             Platform.BUKKIT,
             Platform.BUNGEECORD,
+            Platform.FOLIA,
             Platform.MINESTOM,
             Platform.NUKKIT,
             Platform.SPONGE,

--- a/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
+++ b/example/src/main/java/dev/hypera/chameleon/example/ChameleonExample.java
@@ -57,7 +57,7 @@ import org.jetbrains.annotations.NotNull;
         dependencies = {
             @Dependency(
                 name = "LuckPerms",
-                soft = false,
+                soft = true,
                 platforms = { Platform.BUKKIT, Platform.FOLIA }
             )
         },

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ adventure-platform = "4.3.0"
 # Platforms
 platform-bukkit = "1.19-R0.1-SNAPSHOT"
 platform-bungeecord = "1.19-R0.1-SNAPSHOT"
+platform-folia = "1.19.4-R0.1-SNAPSHOT"
 platform-minestom = "aebf72de90"
 platform-nukkit = "1.0-SNAPSHOT"
 platform-sponge = "9.0.0"
@@ -54,6 +55,7 @@ adventure-platform-bungeecord = { module = "net.kyori:adventure-platform-bungeec
 # Platforms
 platform-bukkit = { module = "org.spigotmc:spigot-api", version.ref = "platform-bukkit" }
 platform-bungeecord = { module = "net.md-5:bungeecord-api", version.ref = "platform-bungeecord" }
+platform-folia = { module = "dev.folia:folia-api", version.ref = "platform-folia" }
 platform-minestom = { module = "com.github.Minestom:Minestom", version.ref = "platform-minestom" }
 platform-nukkit = { module = "cn.nukkit:nukkit", version.ref = "platform-nukkit" }
 platform-sponge = { module = "org.spongepowered:spongeapi", version.ref = "platform-sponge" }

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
@@ -52,8 +52,9 @@ import org.jetbrains.annotations.Nullable;
 
 /**
  * Bukkit Chameleon implementation.
+ * Not final to allow Folia implementation to extend this class.
  */
-public final class BukkitChameleon extends Chameleon {
+public class BukkitChameleon extends Chameleon {
 
     private final @NotNull JavaPlugin plugin;
     private final @NotNull BukkitPlatform platform = new BukkitPlatform();
@@ -65,7 +66,8 @@ public final class BukkitChameleon extends Chameleon {
     private @Nullable ChameleonAudienceProvider audienceProvider;
 
     @Internal
-    BukkitChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Collection<ChameleonExtension<?>> extensions, @NotNull JavaPlugin bukkitPlugin, @NotNull ChameleonPluginData pluginData) throws ChameleonInstantiationException {
+    // Protected to allow Folia to extend this class.
+    protected BukkitChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Collection<ChameleonExtension<?>> extensions, @NotNull JavaPlugin bukkitPlugin, @NotNull ChameleonPluginData pluginData) throws ChameleonInstantiationException {
         super(chameleonPlugin, extensions, pluginData, new ChameleonJavaLogger(bukkitPlugin.getLogger()));
         this.plugin = bukkitPlugin;
     }

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/BukkitChameleon.java
@@ -47,6 +47,7 @@ import java.util.Collection;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.ApiStatus.NonExtendable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -54,6 +55,7 @@ import org.jetbrains.annotations.Nullable;
  * Bukkit Chameleon implementation.
  * Not final to allow Folia implementation to extend this class.
  */
+@NonExtendable
 public class BukkitChameleon extends Chameleon {
 
     private final @NotNull JavaPlugin plugin;

--- a/platform-folia/build.gradle.kts
+++ b/platform-folia/build.gradle.kts
@@ -21,28 +21,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-pluginManagement {
-    includeBuild("build-logic")
-    repositories {
-        gradlePluginPortal()
-    }
+plugins {
+    id("chameleon.common")
+    id("java-library")
 }
 
-rootProject.name = "chameleon-parent"
+repositories {
+    maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/")
+    maven("https://repo.papermc.io/repository/maven-public/")
+}
 
-sequenceOf(
-    "api",
-    "bom",
-    "annotations",
-    "example",
-    "platform-bukkit",
-    "platform-bungeecord",
-    "platform-folia",
-    "platform-minestom",
-    "platform-nukkit",
-    "platform-sponge",
-    "platform-velocity"
-).forEach {
-    include("chameleon-$it")
-    project(":chameleon-$it").projectDir = file(it)
+dependencies {
+    api(project(":chameleon-platform-bukkit"))
+    compileOnlyApi(libs.platform.folia)
 }

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
@@ -66,9 +66,9 @@ public final class FoliaChameleon extends BukkitChameleon {
      * Unsupported.
      *
      * @param chameleonPlugin Unsupported.
-     * @param bukkitPlugin Unsupported.
-     * @param pluginData Unsupported.
-     * @return Unsupported.
+     * @param bukkitPlugin    Unsupported.
+     * @param pluginData      Unsupported.
+     * @return                Unsupported.
      */
     @Deprecated
     public static @NotNull BukkitChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin bukkitPlugin, @NotNull ChameleonPluginData pluginData) {
@@ -89,21 +89,35 @@ public final class FoliaChameleon extends BukkitChameleon {
         return new FoliaChameleonBootstrap(chameleonPlugin, foliaPlugin, pluginData);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull Platform getPlatform() {
         return this.platform != null ? this.platform : super.getPlatform();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull PluginManager getPluginManager() {
         return this.pluginManager != null ? this.pluginManager : super.getPluginManager();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public @NotNull Scheduler getScheduler() {
         return this.scheduler != null ? this.scheduler : super.getScheduler();
     }
 
+    /**
+     * Check if Folia is present.
+     *
+     * @return true if Folia is present.
+     */
     private static boolean isFolia() {
         try {
             // find a better class to use for this?

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
@@ -1,0 +1,98 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia;
+
+import dev.hypera.chameleon.ChameleonPlugin;
+import dev.hypera.chameleon.ChameleonPluginData;
+import dev.hypera.chameleon.exception.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.extension.ChameleonExtension;
+import dev.hypera.chameleon.platform.bukkit.BukkitChameleon;
+import dev.hypera.chameleon.platform.bukkit.BukkitChameleonBootstrap;
+import dev.hypera.chameleon.platform.folia.scheduler.FoliaScheduler;
+import dev.hypera.chameleon.scheduler.Scheduler;
+import java.util.Collection;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus.Experimental;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Folia Chameleon implementation.
+ */
+// We need to extend BukkitChameleon because all Bukkit managers require an instance of it to instantiate. Once this is solved, this can be made its own class.
+@Experimental
+public final class FoliaChameleon extends BukkitChameleon {
+
+    private final @Nullable FoliaScheduler scheduler;
+
+    @Internal
+    FoliaChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Collection<ChameleonExtension<?>> extensions, @NotNull JavaPlugin foliaPlugin, @NotNull ChameleonPluginData pluginData) throws ChameleonInstantiationException {
+        super(chameleonPlugin, extensions, foliaPlugin, pluginData);
+        this.scheduler = isFolia() ? new FoliaScheduler(this) : null;
+    }
+
+    /**
+     * Unsupported.
+     *
+     * @param chameleonPlugin Unsupported.
+     * @param bukkitPlugin Unsupported.
+     * @param pluginData Unsupported.
+     * @return Unsupported.
+     */
+    @Deprecated
+    public static @NotNull BukkitChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin bukkitPlugin, @NotNull ChameleonPluginData pluginData) {
+        throw new UnsupportedOperationException("Folia does not support Bukkit.");
+    }
+
+    /**
+     * Create a new Folia Chameleon bootstrap instance.
+     *
+     * @param chameleonPlugin Chameleon plugin to be loaded.
+     * @param foliaPlugin     Folia JavaPlugin instance.
+     * @param pluginData      Chameleon plugin data.
+     *
+     * @return new Folia Chameleon bootstrap.
+     */
+    @Experimental
+    public static @NotNull FoliaChameleonBootstrap createFoliaBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin foliaPlugin, @NotNull ChameleonPluginData pluginData) {
+        return new FoliaChameleonBootstrap(chameleonPlugin, foliaPlugin, pluginData);
+    }
+
+    @Override
+    public @NotNull Scheduler getScheduler() {
+        return this.scheduler != null ? this.scheduler : super.getScheduler();
+    }
+
+    private static boolean isFolia() {
+        try {
+            // find a better class to use for this?
+            Class.forName("io.papermc.paper.threadedregions.scheduler.AsyncScheduler");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+}

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
@@ -27,8 +27,12 @@ import dev.hypera.chameleon.ChameleonPlugin;
 import dev.hypera.chameleon.ChameleonPluginData;
 import dev.hypera.chameleon.exception.instantiation.ChameleonInstantiationException;
 import dev.hypera.chameleon.extension.ChameleonExtension;
+import dev.hypera.chameleon.platform.Platform;
+import dev.hypera.chameleon.platform.PluginManager;
 import dev.hypera.chameleon.platform.bukkit.BukkitChameleon;
 import dev.hypera.chameleon.platform.bukkit.BukkitChameleonBootstrap;
+import dev.hypera.chameleon.platform.folia.platform.FoliaPlatform;
+import dev.hypera.chameleon.platform.folia.platform.FoliaPluginManager;
 import dev.hypera.chameleon.platform.folia.scheduler.FoliaScheduler;
 import dev.hypera.chameleon.scheduler.Scheduler;
 import java.util.Collection;
@@ -45,12 +49,17 @@ import org.jetbrains.annotations.Nullable;
 @Experimental
 public final class FoliaChameleon extends BukkitChameleon {
 
+    private final @Nullable FoliaPlatform platform;
+    private final @Nullable FoliaPluginManager pluginManager;
     private final @Nullable FoliaScheduler scheduler;
 
     @Internal
     FoliaChameleon(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Collection<ChameleonExtension<?>> extensions, @NotNull JavaPlugin foliaPlugin, @NotNull ChameleonPluginData pluginData) throws ChameleonInstantiationException {
         super(chameleonPlugin, extensions, foliaPlugin, pluginData);
-        this.scheduler = isFolia() ? new FoliaScheduler(this) : null;
+        boolean isFolia = isFolia();
+        this.platform = isFolia ? new FoliaPlatform() : null;
+        this.pluginManager = isFolia ? new FoliaPluginManager() : null;
+        this.scheduler = isFolia ? new FoliaScheduler(this) : null;
     }
 
     /**
@@ -78,6 +87,16 @@ public final class FoliaChameleon extends BukkitChameleon {
     @Experimental
     public static @NotNull FoliaChameleonBootstrap createFoliaBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin foliaPlugin, @NotNull ChameleonPluginData pluginData) {
         return new FoliaChameleonBootstrap(chameleonPlugin, foliaPlugin, pluginData);
+    }
+
+    @Override
+    public @NotNull Platform getPlatform() {
+        return this.platform != null ? this.platform : super.getPlatform();
+    }
+
+    @Override
+    public @NotNull PluginManager getPluginManager() {
+        return this.pluginManager != null ? this.pluginManager : super.getPluginManager();
     }
 
     @Override

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleon.java
@@ -71,6 +71,7 @@ public final class FoliaChameleon extends BukkitChameleon {
      * @return                Unsupported.
      */
     @Deprecated
+    @SuppressWarnings("unused")
     public static @NotNull BukkitChameleonBootstrap create(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin bukkitPlugin, @NotNull ChameleonPluginData pluginData) {
         throw new UnsupportedOperationException("Folia does not support Bukkit.");
     }

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleonBootstrap.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/FoliaChameleonBootstrap.java
@@ -1,0 +1,67 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia;
+
+import dev.hypera.chameleon.ChameleonBootstrap;
+import dev.hypera.chameleon.ChameleonPlugin;
+import dev.hypera.chameleon.ChameleonPluginData;
+import dev.hypera.chameleon.exception.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.extension.ChameleonExtension;
+import dev.hypera.chameleon.logger.ChameleonJavaLogger;
+import dev.hypera.chameleon.logger.ChameleonLogger;
+import dev.hypera.chameleon.platform.folia.extension.ChameleonFoliaExtension;
+import java.util.Collection;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Folia Chameleon bootstrap implementation.
+ */
+public final class FoliaChameleonBootstrap extends ChameleonBootstrap<FoliaChameleon, ChameleonFoliaExtension<?, ?>> {
+
+    private final @NotNull Class<? extends ChameleonPlugin> chameleonPlugin;
+    private final @NotNull JavaPlugin foliaPlugin;
+    private final @NotNull ChameleonPluginData pluginData;
+
+    @Internal
+    FoliaChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull JavaPlugin foliaPlugin, @NotNull ChameleonPluginData pluginData) {
+        this.chameleonPlugin = chameleonPlugin;
+        this.foliaPlugin = foliaPlugin;
+        this.pluginData = pluginData;
+    }
+
+    @Internal
+    @Override
+    protected @NotNull FoliaChameleon loadInternal(@NotNull Collection<ChameleonExtension<?>> extensions) throws ChameleonInstantiationException {
+        return new FoliaChameleon(this.chameleonPlugin, extensions, this.foliaPlugin, this.pluginData);
+    }
+
+    @Internal
+    @Override
+    protected @NotNull ChameleonLogger createLogger() {
+        return new ChameleonJavaLogger(this.foliaPlugin.getLogger());
+    }
+
+}

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/extension/ChameleonFoliaExtension.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/extension/ChameleonFoliaExtension.java
@@ -21,28 +21,19 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-pluginManagement {
-    includeBuild("build-logic")
-    repositories {
-        gradlePluginPortal()
-    }
-}
+package dev.hypera.chameleon.platform.folia.extension;
 
-rootProject.name = "chameleon-parent"
+import dev.hypera.chameleon.extension.ChameleonExtension;
+import dev.hypera.chameleon.extension.ChameleonPlatformExtension;
+import dev.hypera.chameleon.extension.CustomPlatformExtension;
+import dev.hypera.chameleon.platform.folia.FoliaChameleon;
 
-sequenceOf(
-    "api",
-    "bom",
-    "annotations",
-    "example",
-    "platform-bukkit",
-    "platform-bungeecord",
-    "platform-folia",
-    "platform-minestom",
-    "platform-nukkit",
-    "platform-sponge",
-    "platform-velocity"
-).forEach {
-    include("chameleon-$it")
-    project(":chameleon-$it").projectDir = file(it)
+/**
+ * Chameleon Folia extension.
+ *
+ * @param <T> Chameleon extension type.
+ * @param <C> Chameleon platform extension type.
+ */
+public abstract class ChameleonFoliaExtension<T extends ChameleonExtension<C>, C extends CustomPlatformExtension> extends ChameleonPlatformExtension<T, C, FoliaChameleon> {
+
 }

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/FoliaPlatform.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/FoliaPlatform.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia.platform;
+
+import dev.hypera.chameleon.platform.Platform;
+import dev.hypera.chameleon.platform.server.ServerPlatform;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Folia server platform implementation.
+ */
+@Internal
+public final class FoliaPlatform implements ServerPlatform {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String getId() {
+        return Platform.FOLIA;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String getName() {
+        return Bukkit.getName();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String getVersion() {
+        return Bukkit.getVersion();
+    }
+
+}

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/FoliaPluginManager.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/FoliaPluginManager.java
@@ -1,0 +1,70 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia.platform;
+
+import dev.hypera.chameleon.platform.PlatformPlugin;
+import dev.hypera.chameleon.platform.PluginManager;
+import dev.hypera.chameleon.platform.folia.platform.objects.FoliaPlugin;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Folia plugin manager implementation.
+ */
+@Internal
+public final class FoliaPluginManager implements PluginManager {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Collection<PlatformPlugin> getPlugins() {
+        return Arrays.stream(Bukkit.getPluginManager().getPlugins())
+            .map(FoliaPlugin::new)
+            .collect(Collectors.toSet());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Optional<PlatformPlugin> getPlugin(@NotNull String name) {
+        return Optional.ofNullable(Bukkit.getPluginManager().getPlugin(name))
+            .map(FoliaPlugin::new);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isPluginEnabled(@NotNull String name) {
+        return Bukkit.getPluginManager().isPluginEnabled(name);
+    }
+
+}

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/objects/FoliaPlugin.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/objects/FoliaPlugin.java
@@ -1,0 +1,138 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia.platform.objects;
+
+import dev.hypera.chameleon.platform.PlatformPlugin;
+import dev.hypera.chameleon.util.ChameleonUtil;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.Plugin;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Folia platform plugin implementation.
+ */
+@Internal
+public final class FoliaPlugin implements PlatformPlugin {
+
+    private final @NotNull Plugin plugin;
+
+    /**
+     * Folia plugin constructor.
+     *
+     * @param plugin Plugin to be wrapped.
+     */
+    @Internal
+    public FoliaPlugin(@NotNull Plugin plugin) {
+        this.plugin = plugin;
+    }
+
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String getName() {
+        return ChameleonUtil.getOrDefault(this.plugin.getPluginMeta().getName(), "unknown");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull String getVersion() {
+        return ChameleonUtil.getOrDefault(this.plugin.getPluginMeta().getVersion(), "unknown");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Optional<String> getDescription() {
+        return Optional.ofNullable(this.plugin.getPluginMeta().getDescription());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Class<?> getMainClass() {
+        return this.plugin.getClass();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Collection<String> getAuthors() {
+        return ChameleonUtil.getOrDefault(this.plugin.getPluginMeta().getAuthors(), Collections.emptyList());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Set<String> getDependencies() {
+        return new HashSet<>(this.plugin.getPluginMeta().getPluginDependencies());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Set<String> getSoftDependencies() {
+        return new HashSet<>(this.plugin.getPluginMeta().getPluginSoftDependencies());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull Path getDataFolder() {
+        return this.plugin.getDataFolder().toPath().toAbsolutePath();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void enable() {
+        Bukkit.getPluginManager().enablePlugin(this.plugin);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void disable() {
+        Bukkit.getPluginManager().disablePlugin(this.plugin);
+    }
+
+}

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/scheduler/FoliaScheduler.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/scheduler/FoliaScheduler.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2023 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.platform.folia.scheduler;
+
+import dev.hypera.chameleon.platform.folia.FoliaChameleon;
+import dev.hypera.chameleon.scheduler.Schedule;
+import dev.hypera.chameleon.scheduler.ScheduledTask;
+import dev.hypera.chameleon.scheduler.Scheduler;
+import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
+import io.papermc.paper.threadedregions.scheduler.GlobalRegionScheduler;
+import java.util.concurrent.TimeUnit;
+import org.bukkit.Bukkit;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Folia scheduler implementation.
+ */
+@Internal
+public final class FoliaScheduler extends Scheduler {
+
+    private final @NotNull FoliaChameleon chameleon;
+
+    /**
+     * Folia scheduler constructor.
+     *
+     * @param chameleon Folia Chameleon implementation.
+     */
+    @Internal
+    public FoliaScheduler(@NotNull FoliaChameleon chameleon) {
+        this.chameleon = chameleon;
+    }
+
+    @Override
+    protected @NotNull ScheduledTask scheduleAsyncTask(@NotNull Runnable task, @NotNull Schedule delay, @NotNull Schedule repeat) {
+        AsyncScheduler scheduler = Bukkit.getAsyncScheduler();
+        long period = repeat.toMillis();
+        io.papermc.paper.threadedregions.scheduler.ScheduledTask foliaTask = period > 0
+                ? scheduler.runAtFixedRate(this.chameleon.getPlatformPlugin(), t -> task.run(), delay.toMillis(), period, TimeUnit.MILLISECONDS)
+                : scheduler.runDelayed(this.chameleon.getPlatformPlugin(), t -> task.run(), delay.toMillis(), TimeUnit.MILLISECONDS);
+
+        return foliaTask::cancel;
+    }
+
+    @Override
+    protected @NotNull ScheduledTask scheduleSyncTask(@NotNull Runnable task, @NotNull Schedule delay, @NotNull Schedule repeat) {
+        GlobalRegionScheduler scheduler = Bukkit.getGlobalRegionScheduler();
+        long period = repeat.toTicks();
+        io.papermc.paper.threadedregions.scheduler.ScheduledTask foliaTask = period > 0
+                ? scheduler.runAtFixedRate(this.chameleon.getPlatformPlugin(), t -> task.run(), delay.toTicks(), period)
+                : scheduler.runDelayed(this.chameleon.getPlatformPlugin(), t -> task.run(), delay.toTicks());
+
+        return foliaTask::cancel;
+    }
+
+}


### PR DESCRIPTION
**Summary**
Adds Folia support to Chameleon

**Changes**
* Use Paper's plugin loader.
* Use Paper's plugin management API.
* Use Folia's scheduling API.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->