### PR TITLE
fix: minestom extension logger relocation issues

### DIFF
--- a/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/MinestomChameleonBootstrap.java
+++ b/platform-minestom/src/main/java/dev/hypera/chameleon/platform/minestom/MinestomChameleonBootstrap.java
@@ -27,11 +27,14 @@ import dev.hypera.chameleon.ChameleonBootstrap;
 import dev.hypera.chameleon.ChameleonPlugin;
 import dev.hypera.chameleon.ChameleonPluginData;
 import dev.hypera.chameleon.exception.instantiation.ChameleonInstantiationException;
+import dev.hypera.chameleon.logger.ChameleonLogger;
 import dev.hypera.chameleon.logger.ChameleonSlf4jLogger;
 import dev.hypera.chameleon.platform.Platform;
+import dev.hypera.chameleon.util.Preconditions;
 import net.minestom.server.extensions.Extension;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
 
 /**
  * Minestom Chameleon bootstrap implementation.
@@ -44,7 +47,7 @@ final class MinestomChameleonBootstrap extends ChameleonBootstrap<MinestomChamel
 
     @Internal
     MinestomChameleonBootstrap(@NotNull Class<? extends ChameleonPlugin> chameleonPlugin, @NotNull Extension extension, @NotNull ChameleonPluginData pluginData) {
-        super(new ChameleonSlf4jLogger(extension.getLogger()), Platform.MINESTOM);
+        super(createLogger(extension), Platform.MINESTOM);
         this.chameleonPlugin = chameleonPlugin;
         this.extension = extension;
         this.pluginData = pluginData;
@@ -56,6 +59,15 @@ final class MinestomChameleonBootstrap extends ChameleonBootstrap<MinestomChamel
             this.chameleonPlugin, this.extension, this.pluginData,
             this.eventBus, this.logger, this.extensions
         );
+    }
+
+    private static @NotNull ChameleonLogger createLogger(@NotNull Extension extension) {
+        Preconditions.checkNotNull("extension", extension);
+        try {
+            return new ChameleonSlf4jLogger((Logger) Extension.class.getMethod("getLogger").invoke(extension));
+        } catch (ReflectiveOperationException ex) {
+            throw new IllegalStateException(ex);
+        }
     }
 
 }


### PR DESCRIPTION
**Summary**
This pull request adds a workaround for an issue with unrelocated Adventure on Minestom while getting an extension's logger.
Fixes #227
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
 - Retrieve extension logger via reflection to avoid class relocation issues.
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
