### PR TITLE
ci: add support for merge groups, improve performance of publish step

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: "${{ $github.event.action != 'merge_group' }}"
+  cancel-in-progress: "${{ github.event.action != 'merge_group' }}"
 
 env:
   JAVA_VERSION: 18

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,12 +5,13 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  merge_group:
   schedule:
     - cron: "25 6 * * 5"
 
 concurrency:
   group: "${{ github.workflow }}-${{ github.event.number || github.ref }}"
-  cancel-in-progress: true
+  cancel-in-progress: "${{ $github.event.action != 'merge_group' }}"
 
 env:
   JAVA_VERSION: 18

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: "Determine version"
         run: |
-          echo "VERSION=$(./gradlew properties | awk '/^version:/ { print $2; }')" >> $GITHUB_ENV
+          echo "VERSION=$(grep -oP '(?<=version = \").*(?=\")' build.gradle.kts)" >> $GITHUB_ENV
 
       - name: "Import GPG key"
         uses: crazy-max/ghaction-import-gpg@v5.3.0


### PR DESCRIPTION
**Summary**
Add merge group support to `gradle.yml` workflow, improve speed of `Determine version` step in `publish.yml` workflow.
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
 - Add support for `merge_group` event in `gradle.yml` workflow
 - Improve the speed of `Determine version` step in `publish.yml` workflow by using `grep` instead of running the Gradle wrapper.
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
