### PR TITLE
fix(api): add UserChatEvent `#isCancellable` and `#isModifiable`

### DIFF
--- a/api/src/main/java/dev/hypera/chameleon/event/common/UserChatEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/common/UserChatEvent.java
@@ -34,24 +34,30 @@ public final class UserChatEvent extends AbstractCancellable implements UserEven
 
     private final @NotNull User user;
     private @NotNull String message;
+    private final boolean cancellable;
+    private final boolean modifiable;
 
     /**
      * User chat event constructor.
      *
-     * @param user      User that sent the message.
-     * @param message   Message that the user attempted to send.
-     * @param cancelled Whether this event is cancelled.
+     * @param user        User that sent the message.
+     * @param message     Message that the user attempted to send.
+     * @param cancelled   Whether this event is cancelled.
+     * @param cancellable Whether this event can be cancelled on this platform.
+     * @param modifiable  Whether this event can be modified on this platform.
      */
-    public UserChatEvent(@NotNull User user, @NotNull String message, boolean cancelled) {
+    public UserChatEvent(@NotNull User user, @NotNull String message, boolean cancelled, boolean cancellable, boolean modifiable) {
         super(cancelled);
         this.user = user;
         this.message = message;
+        this.cancellable = cancellable;
+        this.modifiable = modifiable;
     }
 
     /**
-     * Get the user who sent this message.
+     * Returns the user who sent this message.
      *
-     * @return the user who sent this message.
+     * @return message sender.
      */
     @Override
     public @NotNull User getUser() {
@@ -59,23 +65,59 @@ public final class UserChatEvent extends AbstractCancellable implements UserEven
     }
 
     /**
-     * Get the message that was sent.
+     * Returns the message that was sent.
      *
-     * @return the message.
+     * @return message.
      */
     public @NotNull String getMessage() {
         return this.message;
     }
 
     /**
-     * Sets the message that was sent.
-     * <p>Due to recent Minecraft changes and the addition of signed message, this may not work
-     * properly on all platforms and versions.</p>
+     * Changes the chat message.
+     * <p>Due to changes in Minecraft 1.19.1+, some platforms no longer support modifying the chat
+     * message. If the current platform does not support changing the chat message, no changes will
+     * be made.</p>
      *
-     * @param message New message that will be sent.
+     * @param message New message.
      */
     public void setMessage(@NotNull String message) {
+        if (!this.modifiable) {
+            return;
+        }
         this.message = message;
+    }
+
+    /**
+     * Returns whether this event can be cancelled.
+     * <p>Due to changes in Minecraft 1.19.1+, some platforms no longer support cancelling signed
+     * chat packets. If the current platform does not support cancelling this event, this will
+     * return {@code false}.</p>
+     *
+     * <p>If this method returns {@code false}, but the event is cancelled, the event will not be
+     * cancelled on the platform to prevent problems from occurring.</p>
+     *
+     * @return {@code true} if this chat event can be cancelled on the underlying platform,
+     *     otherwise {@code false}.
+     */
+    public boolean isCancellable() {
+        return this.cancellable;
+    }
+
+    /**
+     * Returns whether this event can be modified.
+     * <p>Due to changes in Minecraft 1.19.1+, some platforms no longer support modifying the chat
+     * message. If the current platform does not support changing the chat message for this event,
+     * this will return {@code false}.</p>
+     *
+     * <p>If this method returns {@code false}, but the chat message is modified, the event's chat
+     * message will not be changed on the platform to prevent problems from occurring.</p>
+     *
+     * @return {@code true} if this chat event can be modified on the underlying platform, otherwise
+     *     {@code false}.
+     */
+    public boolean isModifiable() {
+        return this.modifiable;
     }
 
 }

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/event/BukkitListener.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/event/BukkitListener.java
@@ -86,7 +86,8 @@ public final class BukkitListener implements Listener {
     public void onAsyncPlayerChatEvent(@NotNull AsyncPlayerChatEvent event) {
         UserChatEvent chameleonEvent = new UserChatEvent(
             this.userManager.wrap(event.getPlayer()),
-            event.getMessage(), event.isCancelled()
+            event.getMessage(), event.isCancelled(),
+            true, true
         );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/event/BungeeCordListener.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/event/BungeeCordListener.java
@@ -89,8 +89,8 @@ public final class BungeeCordListener implements Listener {
     public void onChatEvent(@NotNull ChatEvent event) {
         UserChatEvent chameleonEvent = new UserChatEvent(
             wrap((ProxiedPlayer) event.getSender()),
-            event.getMessage(),
-            event.isCancelled()
+            event.getMessage(), event.isCancelled(),
+            true, true
         );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/event/NukkitListener.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/event/NukkitListener.java
@@ -82,7 +82,8 @@ public final class NukkitListener implements Listener {
     public void onPlayerChatEvent(@NotNull PlayerChatEvent event) {
         UserChatEvent chameleonEvent = new UserChatEvent(
             this.chameleon.getUserManager().wrap(event.getPlayer()),
-            event.getMessage(), event.isCancelled()
+            event.getMessage(), event.isCancelled(),
+            true, true
         );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/event/SpongeListener.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/event/SpongeListener.java
@@ -107,7 +107,10 @@ public final class SpongeListener {
             }
 
             UserChatEvent chameleonEvent = new UserChatEvent(
-                this.chameleon.getUserManager().wrap(sender), serialized, event.isCancelled());
+                this.chameleon.getUserManager().wrap(sender),
+                serialized, event.isCancelled(),
+                true, true
+            );
             this.chameleon.getEventBus().dispatch(chameleonEvent);
 
             if (!serialized.equals(chameleonEvent.getMessage())) {

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityListener.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityListener.java
@@ -29,7 +29,6 @@ import com.velocitypowered.api.event.connection.PostLoginEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent;
 import com.velocitypowered.api.event.player.PlayerChatEvent.ChatResult;
 import com.velocitypowered.api.event.player.ServerConnectedEvent;
-import com.velocitypowered.api.proxy.Player;
 import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.hypera.chameleon.event.common.UserChatEvent;
 import dev.hypera.chameleon.event.common.UserConnectEvent;
@@ -83,19 +82,22 @@ public final class VelocityListener {
      */
     @Subscribe
     public void onChatEvent(@NotNull PlayerChatEvent event) {
+        boolean immutable = event.getPlayer().getProtocolVersion().getProtocol() >= 760;
         UserChatEvent chameleonEvent = new UserChatEvent(
             this.chameleon.getUserManager().wrap(event.getPlayer()),
             event.getMessage(),
-            !event.getResult().isAllowed()
+            !event.getResult().isAllowed(),
+            immutable, immutable
         );
         this.chameleon.getEventBus().dispatch(chameleonEvent);
 
-        if (!event.getMessage().equals(chameleonEvent.getMessage()) &&
-            catchChatModification(event.getPlayer(), false)) {
+        if (immutable) {
+            return;
+        }
+        if (!event.getMessage().equals(chameleonEvent.getMessage())) {
             event.setResult(ChatResult.message(chameleonEvent.getMessage()));
         }
-
-        if (chameleonEvent.isCancelled() && catchChatModification(event.getPlayer(), true)) {
+        if (chameleonEvent.isCancelled()) {
             event.setResult(ChatResult.denied());
         }
     }
@@ -123,26 +125,6 @@ public final class VelocityListener {
             event.getPreviousServer().map(this::wrap).orElse(null),
             wrap(event.getServer())
         ));
-    }
-
-    private boolean catchChatModification(@NotNull Player player, boolean cancel) {
-        if (player.getProtocolVersion().getProtocol() >= 760) {
-            this.chameleon.getInternalLogger().error(
-                "Failed to %s a chat message for a player using 1.19.1 or above, doing so "
-                    + "may result in Velocity throwing an exception and the sender being disconnected.",
-                cancel ? "cancel" : "modify"
-            );
-            this.chameleon.getInternalLogger().error(
-                "This IS NOT a bug, but rather an intentional change in Velocity caused by"
-                    + "changes in Minecraft 1.19.1."
-            );
-            this.chameleon.getInternalLogger().error(
-                "See https://github.com/PaperMC/Velocity/issues/804 for more information."
-            );
-            return false;
-        } else {
-            return true;
-        }
     }
 
     private @NotNull Server wrap(@NotNull RegisteredServer server) {


### PR DESCRIPTION
**Summary**
Due to changes in Minecraft 1.19.1+, some platforms no longer support cancelling or modifying the chat event.

This pull request adds `UserChatEvent#isCancellable()` and `UserChatEvent#isModifiable()` to allow developers to determine whether these operations are supported on the current platform.

If `UserChatEvent#isCancellable()` returns false, but the event is cancelled, the event will not be cancelled on the platform.

If `UserChatEvent#isModifiable()` returns false, but the chat message is modified, the event's chat message will not be changed on the platform.

<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
- Add `UserChatEvent#isCancellable()`
- Add `UserChatEvent#isModifiable()`
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
