### PR TITLE
refactor(api)!: move Cancellable to the event package

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,8 +10,8 @@ address security vulnerabilities that affect the most recent version of this fra
 
 | Version             | Supported          |
 |---------------------|--------------------|
-| `0.17.0-SNAPSHOT`   | :white_check_mark: |
-| < `0.17.0-SNAPSHOT` | :x:                |
+| `0.18.0-SNAPSHOT`   | :white_check_mark: |
+| < `0.18.0-SNAPSHOT` | :x:                |
 
 ### Reporting a Vulnerability
 

--- a/api/src/main/java/dev/hypera/chameleon/event/AbstractCancellable.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/AbstractCancellable.java
@@ -21,39 +21,38 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.event.cancellable;
+package dev.hypera.chameleon.event;
 
 /**
- * Cancellable.
+ * An abstract implementation of {@link Cancellable}.
  */
-public interface Cancellable {
+public abstract class AbstractCancellable implements Cancellable {
+
+    private boolean cancelled;
 
     /**
-     * Cancel the event.
+     * Abstract cancellable constructor.
+     *
+     * @param cancelled Whether this event is cancelled.
      */
-    default void cancel() {
-        setCancelled(true);
+    protected AbstractCancellable(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
     /**
-     * Uncancel the event.
+     * {@inheritDoc}
      */
-    default void uncancel() {
-        setCancelled(false);
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
 
     /**
-     * Set cancelled.
-     *
-     * @param cancelled {@code true} if the event is cancelled, otherwise {@code false}.
+     * {@inheritDoc}
      */
-    void setCancelled(boolean cancelled);
-
-    /**
-     * Whether this event is cancelled.
-     *
-     * @return {@code true} if the event is cancelled, otherwise {@code false}.
-     */
-    boolean isCancelled();
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/event/Cancellable.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/Cancellable.java
@@ -21,38 +21,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-package dev.hypera.chameleon.event.cancellable;
+package dev.hypera.chameleon.event;
 
 /**
- * Cancellable implementation.
+ * Represents an event that can be cancelled.
  */
-public abstract class AbstractCancellable implements Cancellable {
-
-    private boolean cancelled;
+public interface Cancellable {
 
     /**
-     * Abstract cancellable constructor.
+     * Cancels the event.
      *
-     * @param cancelled Whether this event is cancelled.
+     * @see #setCancelled(boolean)
      */
-    protected AbstractCancellable(boolean cancelled) {
-        this.cancelled = cancelled;
+    default void cancel() {
+        setCancelled(true);
     }
 
     /**
-     * {@inheritDoc}
+     * Uncancels the event.
+     *
+     * @see #setCancelled(boolean)
      */
-    @Override
-    public void setCancelled(boolean cancelled) {
-        this.cancelled = cancelled;
+    default void uncancel() {
+        setCancelled(false);
     }
 
     /**
-     * {@inheritDoc}
+     * Sets the event cancelled state.
+     *
+     * @param cancelled {@code true} if the event should be cancelled, otherwise {@code false}.
      */
-    @Override
-    public boolean isCancelled() {
-        return this.cancelled;
-    }
+    void setCancelled(boolean cancelled);
+
+    /**
+     * Returns whether the event has been cancelled.
+     *
+     * @return {@code true} if the event has been cancelled, otherwise {@code false}.
+     */
+    boolean isCancelled();
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/event/EventBusImpl.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/EventBusImpl.java
@@ -23,7 +23,6 @@
  */
 package dev.hypera.chameleon.event;
 
-import dev.hypera.chameleon.event.cancellable.Cancellable;
 import dev.hypera.chameleon.logger.ChameleonLogger;
 import dev.hypera.chameleon.util.Preconditions;
 import java.util.ArrayList;

--- a/api/src/main/java/dev/hypera/chameleon/event/common/UserChatEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/common/UserChatEvent.java
@@ -23,7 +23,7 @@
  */
 package dev.hypera.chameleon.event.common;
 
-import dev.hypera.chameleon.event.cancellable.AbstractCancellable;
+import dev.hypera.chameleon.event.AbstractCancellable;
 import dev.hypera.chameleon.user.User;
 import org.jetbrains.annotations.NotNull;
 

--- a/api/src/main/java/dev/hypera/chameleon/event/common/UserConnectEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/common/UserConnectEvent.java
@@ -23,8 +23,8 @@
  */
 package dev.hypera.chameleon.event.common;
 
-import dev.hypera.chameleon.event.cancellable.AbstractCancellable;
-import dev.hypera.chameleon.event.cancellable.Cancellable;
+import dev.hypera.chameleon.event.AbstractCancellable;
+import dev.hypera.chameleon.event.Cancellable;
 import dev.hypera.chameleon.user.User;
 import net.kyori.adventure.text.Component;
 import org.jetbrains.annotations.ApiStatus.Internal;

--- a/api/src/test/java/dev/hypera/chameleon/event/EventBusTests.java
+++ b/api/src/test/java/dev/hypera/chameleon/event/EventBusTests.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import dev.hypera.chameleon.event.cancellable.AbstractCancellable;
 import dev.hypera.chameleon.logger.DummyChameleonLogger;
 import org.junit.jupiter.api.Test;
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ plugins {
 }
 
 group = "dev.hypera"
-version = "0.17.0-SNAPSHOT"
+version = "0.18.0-SNAPSHOT"
 description = "Cross-platform Minecraft plugin framework"
 
 indraSonatype {


### PR DESCRIPTION
**Summary**
Move the `Cancellable` interface, and the `AbstractCancellable` abstract implementation to the `dev.hypera.chameleon.event` package.
They are currently in `dev.hypera.chameleon.event.cancellable`, when there is really no reason to separate them.
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
- Move the `Cancellable` interface to `dev.hypera.chameleon.event`
- Move the `AbstractCancellable` class to `dev.hypera.chameleon.event`
- Bump the version to `0.18.0-SNAPSHOT`
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
**This pull request contains breaking changes.**
