### PR TITLE
chore: make renovate ignore experimental Spigot API snapshots

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     'config:recommended',
     ':disableRateLimiting',
     'helpers:pinGitHubActionDigests',
-    ':enableVulnerabilityAlerts'
+    ':enableVulnerabilityAlerts',
   ],
   assigneesFromCodeOwners: true,
   configMigration: true,
@@ -14,7 +14,7 @@
   commitMessageExtra: 'to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}',
   commitMessageSuffix: '',
   labels: [
-    'type: dependencies'
+    'type: dependencies',
   ],
   semanticCommits: 'enabled',
   semanticCommitType: 'chore',

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -4,7 +4,7 @@
     'config:recommended',
     ':disableRateLimiting',
     'helpers:pinGitHubActionDigests',
-    ':enableVulnerabilityAlerts',
+    ':enableVulnerabilityAlerts'
   ],
   assigneesFromCodeOwners: true,
   configMigration: true,
@@ -14,9 +14,16 @@
   commitMessageExtra: 'to {{#if isPinDigest}}{{{newDigestShort}}}{{else}}{{#if isMajor}}{{prettyNewMajor}}{{else}}{{#if isSingleVersion}}{{prettyNewVersion}}{{else}}{{#if newValue}}{{{newValue}}}{{else}}{{{newDigestShort}}}{{/if}}{{/if}}{{/if}}{{/if}}',
   commitMessageSuffix: '',
   labels: [
-    'type: dependencies',
+    'type: dependencies'
   ],
   semanticCommits: 'enabled',
   semanticCommitType: 'chore',
   semanticCommitScope: 'deps',
+  packageRules: [
+    {
+      // Ignore Spigot API experimental snapshots
+      matchPackageNames: ['org.spigotmc:spigot-api'],
+      allowedVersions: '!/\\-experimental\\-SNAPSHOT$/',
+    },
+  ],
 }


### PR DESCRIPTION
**Summary**
Make Renovate ignore experimental snapshots for the Spigot API (`org.spigotmc:spigot-api`)
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
 - Add Renovate package rule to disallow Spigot API versions ending with `-experimental-SNAPSHOT`
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
