### PR TITLE
ci(release): reduce permissions to contents read

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - "type: dependencies"
+      - "area: ci"
   categories:
     - title: "⚠️ Breaking changes"
       labels:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: "ubuntu-latest"
     needs: ["validate"]
     permissions:
-      contents: write # 'write' is required to create a release
+      contents: read
     environment:
       name: "release"
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -148,6 +148,9 @@ Additionally, commit message lines should not exceed 100 characters.
 - `users`, when modifying a file that is related to users.
 - `velocity`, when modifying a file inside the `platform-velocity` module.
 
+When using the type `ci`, workflow names (`.github/workflows/` files, excluding extensions) may be
+used as the scope.
+
 #### Code review
 
 We have strict guidelines for merging pull requests to maintain code quality, and to prevent future


### PR DESCRIPTION
**Summary**
Reduce `release` job's permissions to only `contents: read`.
Previously this job required `contents: write` to create releases, however as the job now uses
a @hypera-bot token to create releases, this is no longer required.
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
- Update `release.yml`/`release` to only have required permissions.
- Update `CONTRIBUTING.md` to allow commit scope to use workflow names when type is `ci`.
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
