### PR TITLE
fix(api): rename PlatformPlugin#getDataFolder to #getDataDirectory

### DIFF
--- a/api/src/main/java/dev/hypera/chameleon/platform/PlatformPlugin.java
+++ b/api/src/main/java/dev/hypera/chameleon/platform/PlatformPlugin.java
@@ -87,11 +87,11 @@ public interface PlatformPlugin {
     @NotNull Collection<String> getSoftDependencies();
 
     /**
-     * Get the data folder of this plugin.
+     * Get the data directory of this plugin.
      *
-     * @return data folder.
+     * @return data directory.
      */
-    @NotNull Path getDataFolder();
+    @NotNull Path getDataDirectory();
 
     /**
      * Attempt to enable this plugin.

--- a/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/objects/BukkitPlugin.java
+++ b/platform-bukkit/src/main/java/dev/hypera/chameleon/platform/bukkit/platform/objects/BukkitPlugin.java
@@ -115,7 +115,7 @@ public final class BukkitPlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         return this.plugin.getDataFolder().toPath().toAbsolutePath();
     }
 

--- a/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordPlugin.java
+++ b/platform-bungeecord/src/main/java/dev/hypera/chameleon/platform/bungeecord/platform/objects/BungeeCordPlugin.java
@@ -114,7 +114,7 @@ public final class BungeeCordPlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         return this.plugin.getDataFolder().toPath().toAbsolutePath();
     }
 

--- a/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/objects/FoliaPlugin.java
+++ b/platform-folia/src/main/java/dev/hypera/chameleon/platform/folia/platform/objects/FoliaPlugin.java
@@ -116,7 +116,7 @@ public final class FoliaPlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         return this.plugin.getDataFolder().toPath().toAbsolutePath();
     }
 

--- a/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/plugin/NukkitPlugin.java
+++ b/platform-nukkit/src/main/java/dev/hypera/chameleon/platform/nukkit/platform/plugin/NukkitPlugin.java
@@ -114,7 +114,7 @@ public final class NukkitPlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         return this.plugin.getDataFolder().toPath().toAbsolutePath();
     }
 

--- a/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/plugin/SpongePlugin.java
+++ b/platform-sponge/src/main/java/dev/hypera/chameleon/platform/sponge/platform/plugin/SpongePlugin.java
@@ -116,7 +116,7 @@ public final class SpongePlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         // This is probably the best we can do
         return Sponge.game().gameDirectory().resolve("mods")
             .resolve(this.plugin.metadata().id());

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityPlugin.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/platform/objects/VelocityPlugin.java
@@ -117,7 +117,7 @@ public final class VelocityPlugin implements PlatformPlugin {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull Path getDataFolder() {
+    public @NotNull Path getDataDirectory() {
         return Paths.get("plugins", this.plugin.getDescription().getId());
     }
 


### PR DESCRIPTION
**Summary**
Fixes #291

Renamed the working directory of the platform plugin.

**Changes**
PlatformPlugin
BukkitPlugin
BungeeCordPlugin
FoliaPlugin
NukkitPlugin
SpongePlugin
VelocityPlugin

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->