### PR TITLE
ci(gradle): submit dependency graph (resolves #301)

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -47,6 +47,7 @@ jobs:
       - name: "Build"
         uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2
         with:
+          dependency-graph: "generate"
           arguments: "build"
 
       - name: "Upload reports"
@@ -65,3 +66,16 @@ jobs:
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3
         with:
           fail_ci_if_error: false
+
+  dependency-graph:
+    name: "Dependency Graph"
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    needs: ["build"]
+    permissions:
+      contents: write
+    steps:
+      - name: "Submit Dependency Graph"
+        uses: gradle/gradle-build-action@842c587ad8aa4c68eeba24c396e15af4c2e9f30a # v2
+        with:
+          dependency-graph: "download-and-submit"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "type=$TYPE" >> "$GITHUB_OUTPUT"
           echo "Detected $TYPE version"
 
-      - name: "Set up Indra"
+      - name: "Prepare for publish"
         run: |
           # Indra only publishes release versions if HEAD is tagged
           git tag -a "v$VERSION" HEAD -m "v$VERSION"


### PR DESCRIPTION
**Summary**
Adds Dependency Graph submission to the `gradle.yml` workflow.
This adds a separate step as submission requires `contents: write` permissions, and should only run on pushes.
Resolves #301
<!-- A short summary of what this pull request's intentions are.  -->
<!-- If this pull request resolves an issue, add "Fixes #<id>" at the end of your summary. -->

**Changes**
 - Add Dependency Graph submission to `gradle.yml` workflow
 - Rename `Set up Indra` step in `release.yml` to `Prepare for Release`
<!-- A list of changes this pull request makes  -->

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of 
conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
