### PR TITLE
fix(bungeecord): brigadier not being resolved

### DIFF
--- a/platform-bungeecord/build.gradle.kts
+++ b/platform-bungeecord/build.gradle.kts
@@ -28,6 +28,9 @@ plugins {
 
 repositories {
     sonatype.ossSnapshots()
+
+    // Needed to resolve com.mojang:brigadier used by net.md-5:bungeecord-protocol.
+    maven("https://libraries.minecraft.net/")
 }
 
 dependencies {


### PR DESCRIPTION
**Summary**
BungeeCord made a breaking change in a snapshot build.

`net.md-5:bungeecord-protocol` now requires `com.mojang:brigadier`:
https://github.com/SpigotMC/BungeeCord/commit/0f5f09b6c5f073130515c8cd435541c5c68bcba8#diff-e525b362f47a48b0098711fe063c8200a195c5a9bd98f2bf02e25926b83c4caa

`com.mojang:brigadier` is available from `https://libraries.minecraft.net/`.

Previously, (a fork of) brigadier would be resolved from Sonatype Snapshots,
however md-5 seemingly updated brigadier, and now `bungeecord-protocol` depends on Minecraft's
Maven repository.

**Changes**
- Add `https://libraries.minecraft.net/` repository to the `platform-bungeecord` module.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
