### PR TITLE
ci(release): fix release token not being set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
       HYPERA_RELEASES_PASSWORD: "${{ secrets.HYPERA_RELEASES_PASSWORD }}"
       SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
       SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
+      GITHUB_RELEASE_TOKEN: "${{ secrets.HYPERA_BOT_TOKEN }}"
     with:
       project_name: "Chameleon"
       java_version: 17


### PR DESCRIPTION
**Summary**
Add `GITHUB_RELEASE_TOKEN` secret to the `release.yml` workflow.
This secret is required by the `gradle-release.yml` workflow that is called, and is used to create the GitHub release.

**Changes**
- Add `GITHUB_RELEASE_TOKEN` secret to `release.yml`.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
