### PR TITLE
build!: cleanup adventure serializer dependence

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -28,8 +28,7 @@ plugins {
 
 dependencies {
     api(libs.adventure.api)
-    api(libs.adventure.textSerializer.legacy)
-    api(libs.adventure.textSerializer.gson)
     api(libs.adventure.platform.api)
+    implementation(libs.adventure.textSerializer.gson)
     compileOnlyApi(libs.annotations)
 }

--- a/platform-bukkit/build.gradle.kts
+++ b/platform-bukkit/build.gradle.kts
@@ -35,4 +35,5 @@ dependencies {
     api(projects.chameleonPlatformApi)
     compileOnly(libs.platform.bukkit)
     implementation(libs.adventure.platform.bukkit)
+    implementation(libs.adventure.textSerializer.legacy)
 }

--- a/platform-nukkit/build.gradle.kts
+++ b/platform-nukkit/build.gradle.kts
@@ -33,4 +33,5 @@ repositories {
 dependencies {
     api(projects.chameleonPlatformApi)
     compileOnly(libs.platform.nukkit)
+    implementation(libs.adventure.textSerializer.legacy)
 }


### PR DESCRIPTION
**Summary**
Internally, Chameleon uses the legacy and GSON Adventure component
serializers. However, as they are not a part of the API nor are needed
by end-users, they should not be exposed as `api` dependencies.

Additionally, the legacy serializer is only required by the Bukkit and
Nukkit platform implementations, and should not be a dependency of the
API module.

**Changes**
- Remove dependence on legacy component serializer from API module
- Add dependence on legacy component serializer to Bukkit and Nukkit modules
- Make component serializer dependencies `implementation` to avoid exposing them to end-users.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
