### PR TITLE
ci: adjust for changes in reusable workflows

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -2,7 +2,7 @@
 name: "Gradle"
 on:
   push:
-    branches: [ "main", "releases/**" ]
+    branches: [ "main" ]
     tags-ignore: ["**"]
   pull_request:
     branches: [ "main" ]
@@ -13,4 +13,6 @@ jobs:
     name: "Build"
     uses: HyperaDev/actions/.github/workflows/gradle-build.yml@main
     with:
-      java_version: 17
+      java_version: "21"
+      gradle_warning_mode: "fail"
+      codecov_enabled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 # GitHub Actions workflow to publish releases.
 # Releases are published from the 'releases/<major>' branches.
-name: "Release"
+name: "Gradle"
 on:
   push:
     branches: [ "releases/**" ]
@@ -9,6 +9,10 @@ jobs:
   release:
     name: "Release"
     uses: HyperaDev/actions/.github/workflows/gradle-release.yml@main
+    with:
+      project_name: "Chameleon"
+      java_version: "21"
+      release_maven_central: true
     secrets:
       HYPERA_SIGNING_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
       HYPERA_SIGNING_PASSWORD: "${{ secrets.GPG_PASSPHRASE }}"
@@ -17,7 +21,3 @@ jobs:
       SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
       SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
       GITHUB_RELEASE_TOKEN: "${{ secrets.HYPERA_BOT_TOKEN }}"
-    with:
-      project_name: "Chameleon"
-      java_version: 17
-      release_maven_central: true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,7 +1,7 @@
 # GitHub Actions workflow to publish unstable snapshots.
 # Snapshots are published from the 'main' branch, and should always be considered
 # unstable and unfit for production usage.
-name: "Snapshot"
+name: "Gradle"
 on:
   push:
     branches: [ "main" ]
@@ -10,6 +10,8 @@ jobs:
   snapshot:
     name: "Snapshot"
     uses: HyperaDev/actions/.github/workflows/gradle-snapshot.yml@main
+    with:
+      java_version: "21"
     secrets:
       HYPERA_SIGNING_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
       HYPERA_SIGNING_PASSWORD: "${{ secrets.GPG_PASSPHRASE }}"
@@ -17,5 +19,3 @@ jobs:
       HYPERA_SNAPSHOTS_PASSWORD: "${{ secrets.HYPERA_SNAPSHOTS_PASSWORD }}"
       SONATYPE_USERNAME: "${{ secrets.SONATYPE_USERNAME }}"
       SONATYPE_PASSWORD: "${{ secrets.SONATYPE_PASSWORD }}"
-    with:
-      java_version: 17


### PR DESCRIPTION
**Summary**
Update the GitHub Actions workflows to adjust for changes in `HyperaDev/actions` introduced by https://github.com/HyperaDev/actions/pull/27/

**Changes**
- Run Gradle with Java 21
- Use strings for `java_version` in Gradle workflows
- Set `codecov_enabled: true`, as it now defaults to `false`
- Set name to `Gradle` for all workflows, allowing workflows to appear as `Gradle / Build / Build`, `Gradle / Snapshot / Publish`, etc
- Do not run the `gradle.yml` (build) workflow on release branches
- Tidy up

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
