### PR TITLE
ci(gradle): add codecov token secret

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,3 +16,5 @@ jobs:
       java_version: "21"
       gradle_warning_mode: "fail"
       codecov_enabled: true
+    secrets:
+      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
**Summary**
Add `CODECOV_TOKEN` secret to `gradle.yml` workflow.
This is needed because HyperaDev/actions now uses `codecov/codecov-action@v4.0.0`.

Related: https://github.com/HyperaDev/actions/pull/30

**Changes**
- Add `CODECOV_TOKEN` secret to the `gradle.yml` workflow.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
