### PR TITLE
ci: add concurrency groups

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "main" ]
   merge_group:
 
+concurrency: "gradle-build-${{ github.event.number || github.ref }}"
+
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: [ "releases/**" ]
 
+concurrency: "gradle-release-${{ github.ref }}"
+
 jobs:
   release:
     name: "Release"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -6,6 +6,8 @@ on:
   push:
     branches: [ "main" ]
 
+concurrency: "gradle-snapshot-${{ github.ref }}"
+
 jobs:
   snapshot:
     name: "Snapshot"


### PR DESCRIPTION
**Summary**
Add concurrency groups to the GitHub Actions workflows.
Previously these were done in the reusable workflows, however this is no longer the case as of https://github.com/HyperaDev/actions/pull/31.

**Changes**
- Add concurrency groups to each GitHub Actions workflow.

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
