### PR TITLE
chore(deps)!: update velocity-api to v3.3.0-SNAPSHOT

### DIFF
--- a/build-logic/src/main/kotlin/chameleon.base.gradle.kts
+++ b/build-logic/src/main/kotlin/chameleon.base.gradle.kts
@@ -43,6 +43,7 @@ val requires17 = setOf(
     "chameleon-example",
     "chameleon-platform-bukkit",
     "chameleon-platform-sponge",
+    "chameleon-platform-velocity",
 )
 
 indra {

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -28,8 +28,8 @@ plugins {
 }
 
 /*
- * Chameleon requires Java 11. Additionally, Bukkit (Paper, Folia) and Sponge support requires Java 17.
- * If you wish to support Bukkit (Paper, Folia) and/or Sponge, you must target Java 17.
+ * Chameleon requires Java 11. Additionally, Bukkit (Paper, Folia), Sponge and Velocity support requires Java 17.
+ * If you wish to support Bukkit (Paper, Folia), Sponge and/or Velocity, you must target Java 17.
  *
  * If you want your plugin to work with Java 11+, you must keep your source code
  * compatible with Java 11.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ bukkit = "1.20.2-R0.1-SNAPSHOT"
 bungeecord = "1.20-R0.3-SNAPSHOT"
 nukkit = "1.0-SNAPSHOT"
 sponge = "10.0.0"
-velocity = "3.2.0-SNAPSHOT"
+velocity = "3.3.0-SNAPSHOT"
 
 # File formats
 gson = "2.10.1"


### PR DESCRIPTION
**Summary**
Update velocity-api to v3.3.0-SNAPSHOT.

**Note: `chameleon-platform-velocity` now requires Java 17.**

**Changes**
- Use Java 17 for `chameleon-platform-velocity` (breaking)
- Update `com.velocitypowered:velocity-api` to `v3.3.0-SNAPSHOT`

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes.

**This pull request contains breaking changes.**
