### PR TITLE
refactor(event)!: add ProxyUser{,Server}ConnectedEvent

### DIFF
--- a/api/src/main/java/dev/hypera/chameleon/event/common/UserConnectEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/common/UserConnectEvent.java
@@ -32,7 +32,11 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /**
- * User connect event, dispatched when a user joins the proxy/server.
+ * This event is dispatched when the user has connected to the server or proxy.
+ *
+ * <p>On proxy platforms, the user may not have been connected to a server yet.
+ * {@link dev.hypera.chameleon.event.proxy.ProxyUserConnectedEvent} will be dispatched once the user
+ * has connected to the proxy and has been connected to a server.</p>
  */
 public final class UserConnectEvent extends AbstractCancellable implements UserEvent, Cancellable {
 
@@ -40,7 +44,7 @@ public final class UserConnectEvent extends AbstractCancellable implements UserE
     private @NotNull Component cancelReason = Component.text("Disconnected");
 
     /**
-     * User connect event constructor.
+     * Constructs a UserConnectEvent.
      *
      * @param user      The user who connected.
      * @param cancelled Whether this event has been cancelled.
@@ -52,9 +56,9 @@ public final class UserConnectEvent extends AbstractCancellable implements UserE
     }
 
     /**
-     * Get the user who connected.
+     * Returns the user who connected.
      *
-     * @return connecting user.
+     * @return connected user.
      */
     @Override
     public @NotNull User getUser() {
@@ -84,7 +88,7 @@ public final class UserConnectEvent extends AbstractCancellable implements UserE
     }
 
     /**
-     * Get the reason used when kicking the player if this event is cancelled.
+     * Returns the reason used when kicking the player if this event is cancelled.
      *
      * @return cancel reason.
      */

--- a/api/src/main/java/dev/hypera/chameleon/event/proxy/ProxyUserConnectedEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/proxy/ProxyUserConnectedEvent.java
@@ -25,39 +25,43 @@ package dev.hypera.chameleon.event.proxy;
 
 import dev.hypera.chameleon.platform.proxy.Server;
 import dev.hypera.chameleon.user.ProxyUser;
-import java.util.Optional;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
- * Proxy user switch sever event, dispatched whenever a player switches server.
+ * This event is dispatched once the user has successfully connected to the proxy and has been
+ * connected to a server.
+ *
+ * <p>This is similar to {@link ProxyUserServerConnectedEvent}, however this is only dispatched on
+ * the initial server connection after the user has connected to the proxy.</p>
+ *
+ * <p>{@link ProxyUserServerConnectedEvent} will also be dispatched, however
+ * {@link ProxyUserServerConnectedEvent#getPreviousServer()} will return an empty optional for the
+ * initial connection, as the user was not previously connected to a server.</p>
+ *
+ * @see ProxyUserServerConnectedEvent
  */
-public final class ProxyUserSwitchEvent implements ProxyUserEvent {
+public final class ProxyUserConnectedEvent implements ProxyUserEvent {
 
     private final @NotNull ProxyUser user;
-    private final @Nullable Server from;
-    private final @NotNull Server to;
+    private final @NotNull Server server;
 
     /**
-     * Proxy user switch event constructor.
+     * Constructs a ProxyUserConnectedEvent.
      *
-     * @param user The proxy user who switched server.
-     * @param from The server the user switched from.
-     * @param to   The server the user switched to.
+     * @param user   User who connected.
+     * @param server Server the user connected to.
      */
     @Internal
-    public ProxyUserSwitchEvent(@NotNull ProxyUser user, @Nullable Server from, @NotNull Server to) {
+    public ProxyUserConnectedEvent(@NotNull ProxyUser user, @NotNull Server server) {
         this.user = user;
-        this.from = from;
-        this.to = to;
+        this.server = server;
     }
 
-
     /**
-     * Get the user who switched server.
+     * Returns the user who connected.
      *
-     * @return the user who switched server.
+     * @return connected user.
      */
     @Override
     public @NotNull ProxyUser getUser() {
@@ -65,22 +69,12 @@ public final class ProxyUserSwitchEvent implements ProxyUserEvent {
     }
 
     /**
-     * The server the user switched from, if available.
+     * Returns the server the user connected to.
      *
-     * @return an optional containing the server the user switched from, if available, otherwise an
-     *     empty optional.
+     * @return connected server.
      */
-    public @NotNull Optional<Server> getFrom() {
-        return Optional.ofNullable(this.from);
-    }
-
-    /**
-     * The server the user switched to.
-     *
-     * @return the server the user switched to.
-     */
-    public @NotNull Server getTo() {
-        return this.to;
+    public @NotNull Server getServer() {
+        return this.server;
     }
 
 }

--- a/api/src/main/java/dev/hypera/chameleon/event/proxy/ProxyUserServerConnectedEvent.java
+++ b/api/src/main/java/dev/hypera/chameleon/event/proxy/ProxyUserServerConnectedEvent.java
@@ -1,0 +1,92 @@
+/*
+ * This file is a part of the Chameleon Framework, licensed under the MIT License.
+ *
+ * Copyright (c) 2021-2024 The Chameleon Framework Authors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package dev.hypera.chameleon.event.proxy;
+
+import dev.hypera.chameleon.platform.proxy.Server;
+import dev.hypera.chameleon.user.ProxyUser;
+import java.util.Optional;
+import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * This event is dispatched once a user connected to the proxy has successfully connected to a
+ * server.
+ *
+ * @see ProxyUserConnectedEvent
+ */
+public final class ProxyUserServerConnectedEvent implements ProxyUserEvent {
+
+    private final @NotNull ProxyUser user;
+    private final @NotNull Server server;
+    private final @Nullable Server previousServer;
+
+    /**
+     * Constructs a ProxyUserServerConnectedEvent.
+     *
+     * @param user           The user that was connected to the server.
+     * @param server         The server the user has connected to.
+     * @param previousServer The server the user was previously connected to, {@code null} if none.
+     */
+    @Internal
+    public ProxyUserServerConnectedEvent(@NotNull ProxyUser user, @NotNull Server server, @Nullable Server previousServer) {
+        this.user = user;
+        this.server = server;
+        this.previousServer = previousServer;
+    }
+
+
+    /**
+     * Returns the user who switched between the servers.
+     *
+     * @return the user who switched server.
+     */
+    @Override
+    public @NotNull ProxyUser getUser() {
+        return this.user;
+    }
+
+    /**
+     * Returns the server the user has connected to.
+     *
+     * @return the connected server.
+     */
+    public @NotNull Server getServer() {
+        return this.server;
+    }
+
+    /**
+     * Returns the server the user was previously connected to.
+     *
+     * <p>This will return an empty optional if the user was not previously connected to a server,
+     * such as on the initial server connection after the user has connected to the proxy.</p>
+     *
+     * @return an optional containing the previously connected server, if available, otherwise an
+     *     empty optional.
+     */
+    public @NotNull Optional<Server> getPreviousServer() {
+        return Optional.ofNullable(this.previousServer);
+    }
+
+}

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityEventDispatcher.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityEventDispatcher.java
@@ -34,7 +34,8 @@ import com.velocitypowered.api.proxy.server.RegisteredServer;
 import dev.hypera.chameleon.event.common.UserChatEvent;
 import dev.hypera.chameleon.event.common.UserConnectEvent;
 import dev.hypera.chameleon.event.common.UserDisconnectEvent;
-import dev.hypera.chameleon.event.proxy.ProxyUserSwitchEvent;
+import dev.hypera.chameleon.event.proxy.ProxyUserConnectedEvent;
+import dev.hypera.chameleon.event.proxy.ProxyUserServerConnectedEvent;
 import dev.hypera.chameleon.platform.event.PlatformEventDispatcher;
 import dev.hypera.chameleon.platform.proxy.Server;
 import dev.hypera.chameleon.platform.util.PlatformEventUtil;
@@ -43,6 +44,7 @@ import dev.hypera.chameleon.platform.velocity.platform.objects.VelocityServer;
 import dev.hypera.chameleon.user.ProxyUser;
 import dev.hypera.chameleon.user.User;
 import org.jetbrains.annotations.ApiStatus.Internal;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -92,7 +94,7 @@ public final class VelocityEventDispatcher extends PlatformEventDispatcher {
         User user = this.chameleon.getUserManager().wrapUser(event.getPlayer());
         UserConnectEvent chameleonEvent = new UserConnectEvent(user, false);
 
-        this.chameleon.getEventBus().dispatch(chameleonEvent);
+        dispatch(chameleonEvent);
         if (chameleonEvent.isCancelled()) {
             user.disconnect(chameleonEvent.getCancelReason());
         }
@@ -113,7 +115,7 @@ public final class VelocityEventDispatcher extends PlatformEventDispatcher {
             !event.getResult().isAllowed(),
             immutable, immutable
         );
-        this.chameleon.getEventBus().dispatch(chameleonEvent);
+        dispatch(chameleonEvent);
 
         // Event message modification
         if (!event.getMessage().equals(chameleonEvent.getMessage())) {
@@ -141,8 +143,8 @@ public final class VelocityEventDispatcher extends PlatformEventDispatcher {
      */
     @Subscribe
     public void onPlayerDisconnectEvent(@NotNull DisconnectEvent event) {
-        this.chameleon.getEventBus().dispatch(new UserDisconnectEvent(
-            this.chameleon.getUserManager().wrapUser(event.getPlayer())));
+        dispatch(new UserDisconnectEvent(this.chameleon.getUserManager()
+            .wrapUser(event.getPlayer())));
     }
 
     /**
@@ -151,15 +153,21 @@ public final class VelocityEventDispatcher extends PlatformEventDispatcher {
      * @param event Platform event.
      */
     @Subscribe
-    public void onServerSwitchEvent(@NotNull ServerConnectedEvent event) {
-        this.chameleon.getEventBus().dispatch(new ProxyUserSwitchEvent(
-            (ProxyUser) this.chameleon.getUserManager().wrapUser(event.getPlayer()),
-            event.getPreviousServer().map(this::wrap).orElse(null),
-            wrap(event.getServer())
-        ));
+    public void onServerConnectedEvent(@NotNull ServerConnectedEvent event) {
+        ProxyUser user = (ProxyUser) this.chameleon.getUserManager().wrapUser(event.getPlayer());
+        Server server = wrapServer(event.getServer());
+
+        if (event.getPreviousServer().isEmpty()) {
+            // Dispatched on initial connection only.
+            dispatch(new ProxyUserConnectedEvent(user, server));
+        }
+
+        dispatch(new ProxyUserServerConnectedEvent(user, server,
+            event.getPreviousServer().map(this::wrapServer).orElse(null)));
     }
 
-    private @NotNull Server wrap(@NotNull RegisteredServer server) {
+    @Contract(value = "_ -> new", pure = true)
+    private @NotNull Server wrapServer(@NotNull RegisteredServer server) {
         return new VelocityServer(this.chameleon, server);
     }
 


### PR DESCRIPTION
**Summary**
Add `ProxyUserConnectedEvent` which is dispatched once the user has successfully connected to the proxy and has been connected to a server.

Rename `ProxyUserSwitchEvent` to `ProxyUserServerConnectedEvent`, as the new naming makes a lot more sense in the context of how the proxy works and when the event is dispatched.

**Changes**
- Add `ProxyUserConnectedEvent`
- Refactor `ProxyUserSwitchEvent` into `ProxyUserServerConnectedEvent` (`#getFrom()` -> `#getPreviousServer()`, `#getTo()` -> `#getServer()`)
- Improve javadoc in `UserConnectEvent`

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
**This pull request contains breaking changes.**
