### PR TITLE
feat(velocity): add property to change behaviour of chat cancel/modification

### DIFF
--- a/api/src/main/java/dev/hypera/chameleon/util/internal/ChameleonProperty.java
+++ b/api/src/main/java/dev/hypera/chameleon/util/internal/ChameleonProperty.java
@@ -82,8 +82,7 @@ public interface ChameleonProperty<T> {
      * @return property name.
      */
     @Contract(value = "-> _", pure = true)
-    @NotNull
-    String name();
+    @NotNull String name();
 
     /**
      * Returns the value of this property.
@@ -91,8 +90,7 @@ public interface ChameleonProperty<T> {
      * @return property value.
      */
     @Contract(value = "-> _", pure = true)
-    @NotNull
-    T get();
+    @NotNull T get();
 
     /**
      * Sets the value of this property.

--- a/api/src/main/java/dev/hypera/chameleon/util/internal/ChameleonProperty.java
+++ b/api/src/main/java/dev/hypera/chameleon/util/internal/ChameleonProperty.java
@@ -52,6 +52,16 @@ public interface ChameleonProperty<T> {
     @NotNull ChameleonProperty<Boolean> LOG_ERRORS = of("logErrors", Boolean::parseBoolean, true);
 
     /**
+     * Specifies whether Chameleon should attempt to prevent illegal protocol errors when handling
+     * chat events on proxy platforms.
+     *
+     * <p>On Velocity, the proxy will kick the player to prevent an illegal protocol state if the
+     * plugin attempts to cancel or modify a chat message. If this is enabled, Chameleon will not
+     * allow the cancellation or modification of chat events when the player may be kicked.</p>
+     */
+    @NotNull ChameleonProperty<Boolean> PREVENT_CHAT_PROTOCOL_ERRORS = of("preventChatProtocolErrors", Boolean::parseBoolean, true);
+
+    /**
      * Returns a new property.
      *
      * @param name         Property name.
@@ -72,7 +82,8 @@ public interface ChameleonProperty<T> {
      * @return property name.
      */
     @Contract(value = "-> _", pure = true)
-    @NotNull String name();
+    @NotNull
+    String name();
 
     /**
      * Returns the value of this property.
@@ -80,7 +91,8 @@ public interface ChameleonProperty<T> {
      * @return property value.
      */
     @Contract(value = "-> _", pure = true)
-    @NotNull T get();
+    @NotNull
+    T get();
 
     /**
      * Sets the value of this property.

--- a/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityEventDispatcher.java
+++ b/platform-velocity/src/main/java/dev/hypera/chameleon/platform/velocity/event/VelocityEventDispatcher.java
@@ -42,6 +42,7 @@ import dev.hypera.chameleon.platform.velocity.VelocityChameleon;
 import dev.hypera.chameleon.platform.velocity.platform.objects.VelocityServer;
 import dev.hypera.chameleon.user.ProxyUser;
 import dev.hypera.chameleon.user.User;
+import dev.hypera.chameleon.util.internal.ChameleonProperty;
 import org.jetbrains.annotations.ApiStatus.Internal;
 import org.jetbrains.annotations.NotNull;
 
@@ -105,8 +106,9 @@ public final class VelocityEventDispatcher extends PlatformEventDispatcher {
      */
     @Subscribe
     public void onChatEvent(@NotNull PlayerChatEvent event) {
-        boolean immutable = event.getPlayer().getProtocolVersion()
-            .compareTo(ProtocolVersion.MINECRAFT_1_19_1) >= 0;
+        boolean immutable = ChameleonProperty.PREVENT_CHAT_PROTOCOL_ERRORS.get() &&
+            event.getPlayer().getProtocolVersion().compareTo(ProtocolVersion.MINECRAFT_1_19_1) >= 0;
+
         UserChatEvent chameleonEvent = new UserChatEvent(
             this.chameleon.getUserManager().wrapUser(event.getPlayer()),
             event.getMessage(),


### PR DESCRIPTION
**Summary**
Add `ChameleonProperty.PREVENT_CHAT_PROTOCOL_ERRORS` which can be set to `false` to prevent Chameleon from preventing chat events from being cancelled or modified for players with protocol version 760 or newer.

Plugins like [SignedVelocity](https://github.com/4drian3d/SignedVelocity) can be used to workaround players being kicked if these events are cancelled or modified, so we want to allow plugins to change this behaviour if they wish.

**Changes**
- Add `ChameleonProperty.PREVENT_CHAT_PROTOCOL_ERRORS` property (naming can be changed)

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
