### PR TITLE
build: switch to Goooler/shadow fork

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -24,7 +24,7 @@
 plugins {
     id("java")
     id("chameleon.base") // Checkstyle and version injection, not required.
-    id("com.github.johnrengelman.shadow") version "8.1.1"
+    alias(libs.plugins.shadow)
 }
 
 /*

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ errorprone-plugin = "4.0.0"
 nullaway = "0.11.0"
 nullaway-plugin = "2.0.0"
 nexusPublish = "2.0.0"
+shadow = "8.1.7"
 
 # Test
 junit = "5.10.2"
@@ -102,3 +103,4 @@ test-mockito-junit = { module = "org.mockito:mockito-junit-jupiter" }
 [plugins]
 indra-sonatype = { id = "net.kyori.indra.publishing.sonatype", version.ref = "indra" }
 nexusPublish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublish" }
+shadow = { id = "io.github.goooler.shadow", version.ref = "shadow" }


### PR DESCRIPTION
**Summary**
The Gradle shadow plugin by johnrengelman is currently unmaintained, and does not currently support the latest versions of Gradle.

There have been discussions regarding the future of the plugin, however nothing has been acted upon currently: johnrengelman/shadow#908

This fork appears to be the most supported and best maintained fork, and has been suggested as the replacement for the original shadow plugin.

Fixes #414
Related to #410

**Changes**
- Use https://github.com/Goooler/shadow instead of https://github.com/johnrengelman/shadow
- Use `gradle/libs.version.toml` for shadow plugin

**Checklist**
- [x] I acknowledge and agree to the terms of the [Developer Certificate of Origin](https://developercertificate.org/).
- [x] All contributed code can be distributed under the terms of the [MIT License](https://github.com/ChameleonFramework/Chameleon/blob/main/LICENSE).
- [x] I have read the [contributing guidelines](https://github.com/ChameleonFramework/Chameleon/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/ChameleonFramework/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I have checked the ["Allow edit from maintainers"](https://help.github.com/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork/) option.
- [ ] I have added appropriate unit tests for my changes. <!-- Not required if the change is small or cannot be easily tested. -->

<!-- If your change is breaks the current API, uncomment the following: -->
<!-- **This pull request contains breaking changes.** -->
